### PR TITLE
Update VoltageCalibration.cc

### DIFF
--- a/src/VoltageCalibration.cc
+++ b/src/VoltageCalibration.cc
@@ -303,7 +303,7 @@ void mattak::VoltageCalibration::recalculateFits(int order, double min, double m
       for (int j = jmin ; j <= jmax; j++) 
       {
 
-        double adc = scan_result[j][ichan][i]; 
+        double adc = scan_result[j][ichan][i] - adc_offset[ichan]; 
         double meas = ichan < mattak::k::num_radiant_channels / 2 ? vbias[0][j]: vbias[1][j]; 
         meas -= vref; 
         double pred = evalPars(adc, fit_order, &fit_coeffs[ichan][i * (order+1)]); 


### PR DESCRIPTION
In the calculation of **max deviation** and **chi square**, the **ADC offset subtraction** was added (line 306):
`double adc = scan_result[j][ichan][i] - adc_offset[ichan];`
As it was previously done in line 244 in the calculation for the fit coefficient.