### PR TITLE
Add interface to iterate only over events of a certain trigger type

### DIFF
--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -1,157 +1,160 @@
 ### Python dataset class, agnostic to backend
 
 
-import os 
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import typing
-from typing import Sequence, Union, Tuple, Optional, Generator
-import numpy 
-import datetime 
+from typing import Sequence, Union, Tuple, Optional, Generator, Callable
+import numpy
+import datetime
 
 
-@dataclass 
-class EventInfo: 
+@dataclass
+class EventInfo:
     """ Pure python event information. In effect duplicating the most important bits of the ROOT header"""
-    eventNumber: int 
+    eventNumber: int
     station : int
     run: int
     readoutTime : float
     triggerTime : float
     triggerType: str
     sysclk: int
-    sysclkLastPPS: Tuple[int,int]  # the last 2 PPS sysclks, most recent first
-    pps: int 
+    sysclkLastPPS: Tuple[int, int]  # the last 2 PPS sysclks, most recent first
+    pps: int
     radiantStartWindows: numpy.ndarray
-    sampleRate: float  # Sample rate, in GSa/s 
+    sampleRate: float  # Sample rate, in GSa/s
 
 ##
-class AbstractDataset(ABC): 
+class AbstractDataset(ABC):
     """ Abstract Base Class for accessing RNO-G data in Python , implemented either with uproot or PyROOT"""
 
-    def setEntries( self, i : Union[int,Tuple[int,int]]):
+    def setEntries( self, i : Union[int, Tuple[int, int]]):
         """
         Select entries to read out with wfs or eventInfo. Can either be a
         single entry or a tuple representating start and end entries, exclusive.
-        Use (0,dataset.N()) or (0, None) to select all events. Negative indices indicate from end. 
-        """ 
+        Use (0,dataset.N()) or (0, None) to select all events. Negative indices indicate from end.
+        """
 
         if isinstance(i, tuple):
             self.multiple  = True
             self.first = i[0]
             self.last = i[1]
             if self.last is None:
-                self.last = self.N() 
-            if self.first < 0: 
+                self.last = self.N()
+            if self.first < 0:
                 self.first += self.N()
-            if self.last < 0: 
+            if self.last < 0:
                 self.last += self.N()
 
             if self.last > self.N():
-                self.last = self.N() 
+                self.last = self.N()
         else:
             self.multiple = False
             self.entry = i
             self.first = i
             self.last = i+1
- 
 
-    def N(self) -> int: 
+
+    def N(self) -> int:
         """ Return the number of events available in this dataset"""
         return 0
 
 
     @abstractmethod
     def _iterate(self, start: int , stop : Union[int,None] , calibrated: bool, max_entries_in_mem: int)-> Generator[Tuple[EventInfo, numpy.ndarray],None,None]:
-        """ implementation-defined part of iterator"""
+        """ implementation-defined part of iterator """
         pass
 
-    def iterate(self, start : int = 0, stop : Union[int,None] = None,  calibrated: bool = False, max_entries_in_mem : int = 256, trigger=None) -> Generator[Optional[Tuple[EventInfo, numpy.ndarray]],None,None]:
+    def iterate(self, start : int = 0, stop : Union[int,None] = None,
+                calibrated: bool = False, max_entries_in_mem : int = 256,
+                selector: Optional[Callable[[EventInfo], bool]] = None) \
+                -> Generator[Optional[Tuple[EventInfo, numpy.ndarray]], None, None]:
         """ Iterate over events from start to stop, holding at most max_entries_in_mem in RAM.
-            Returns a tuple of EventInfo and the event waveforms (potentially calibrated). 
+            Returns a tuple of EventInfo and the event waveforms (potentially calibrated).
         """
-        if start < 0: 
-            start += self.N() 
-        if start < 0 or start > self.N(): 
+        if start < 0:
+            start += self.N()
+        if start < 0 or start > self.N():
             return
 
-        if stop is None: 
+        if stop is None:
             stop = self.N()
-        
-        if stop < 0: 
-            stop += self.N() 
 
-        if stop < 0 or start > self.N(): 
-            return 
+        if stop < 0:
+            stop += self.N()
 
-        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, trigger) 
+        if stop < 0 or start > self.N():
+            return
+
+        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, selector)
 
 
 
     @abstractmethod
-    def eventInfo(self) -> Union[Optional[EventInfo],Sequence[Optional[EventInfo]]]:
-        """Get selected event info(s) 
+    def eventInfo(self) -> Union[Optional[EventInfo], Sequence[Optional[EventInfo]]]:
+        """Get selected event info(s)
            Depending on what was passed to setEntries this can return either one EventInfo or a list of them
         """
         pass
 
     @abstractmethod
-    def wfs(self, calibrated : bool = False) -> Optional[numpy.ndarray]:  
-        """ Get select waveform(s). 
+    def wfs(self, calibrated : bool = False) -> Optional[numpy.ndarray]:
+        """ Get select waveform(s).
             Depending on what was passed to setEntries, this may be a single waveform or many
         """
         pass
 
 
-def Dataset(station : int, run : int, data_dir : str = None, backend : str= "auto", verbose : bool = False, skip_incomplete : bool = True) -> Optional[AbstractDataset]: 
+def Dataset(station : int, run : int, data_dir : str = None, backend : str= "auto", verbose : bool = False, skip_incomplete : bool = True) -> Optional[AbstractDataset]:
    """
-   This is not a class, but a factory method! 
+   This is not a class, but a factory method!
    Returns a dataset corresponding to the station and run using data_dir as the base. If data_dir is not defined,
    then the environmental variable RNO_G_DATA will be used. The backend can be chosen explicitly or auto will try to
-   use the best one (PyROOT if available, otherwise will rever tto uproot). 
+   use the best one (PyROOT if available, otherwise will rever tto uproot).
 
    There is a special case of setting station = 0 and run = 0 and data_dir will
    be interpreted as a directory containing ROOT files, useful if you don't
    have the full directory hierarchy setup or want to look at data taken with
    the fakedaq.
-   
+
    verbose prints out things mostly useful for debugging.
 
    skip_incomplete affects what happens when a dataset is incomplete
    (telemetered). If True, will only index fully telemetered events. If False,
    will be indexed by full dataset, but untelemetered events will have
    waveforms of None type (if requested singly) or be all 0's (if requested
-   via the bulk interface, as numpy doesn't support jagged ararys). 
+   via the bulk interface, as numpy doesn't support jagged ararys).
 
    """
 
-   if data_dir is None: 
-       data_dir = os.environ['RNO_G_DATA'] 
+   if data_dir is None:
+       data_dir = os.environ['RNO_G_DATA']
 
    if backend == "auto":
-        try: 
-            import ROOT 
-            import mattak.backends.pyroot.mattakloader 
-            if verbose: 
-                print('Using pyroot backend') 
-            backend = "pyroot" 
-        except: 
-            try: 
+        try:
+            import ROOT
+            import mattak.backends.pyroot.mattakloader
+            if verbose:
+                print('Using pyroot backend')
+            backend = "pyroot"
+        except:
+            try:
                 import uproot
-                backend = "uproot" 
-                if verbose: 
-                    print('Using uproot backend') 
+                backend = "uproot"
+                if verbose:
+                    print('Using uproot backend')
             except:
                 print("No backends available")
-                return None 
-                
-   if backend == "uproot": 
-        import mattak.backends.uproot.dataset 
+                return None
+
+   if backend == "uproot":
+        import mattak.backends.uproot.dataset
         return mattak.backends.uproot.dataset.Dataset(station, run, data_dir, verbose, skip_incomplete)
-   elif backend == "pyroot": 
-        import mattak.backends.pyroot.dataset 
-        return mattak.backends.pyroot.dataset.Dataset(station, run, data_dir, verbose, skip_incomplete) 
-   else: 
+   elif backend == "pyroot":
+        import mattak.backends.pyroot.dataset
+        return mattak.backends.pyroot.dataset.Dataset(station, run, data_dir, verbose, skip_incomplete)
+   else:
        print("Unknown backend (known backends are \"uproot\" and \"pyroot\")")
-       return None 
+       return None
 

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -66,7 +66,7 @@ class AbstractDataset(ABC):
         """ implementation-defined part of iterator"""
         pass
 
-    def iterate(self, start : int = 0, stop : Union[int,None] = None,  calibrated: bool = False, max_entries_in_mem : int = 256) -> Generator[Optional[Tuple[EventInfo, numpy.ndarray]],None,None]:
+    def iterate(self, start : int = 0, stop : Union[int,None] = None,  calibrated: bool = False, max_entries_in_mem : int = 256, trigger=None) -> Generator[Optional[Tuple[EventInfo, numpy.ndarray]],None,None]:
         """ Iterate over events from start to stop, holding at most max_entries_in_mem in RAM.
             Returns a tuple of EventInfo and the event waveforms (potentially calibrated). 
         """
@@ -84,7 +84,7 @@ class AbstractDataset(ABC):
         if stop < 0 or start > self.N(): 
             return 
 
-        yield from self._iterate(start,stop,calibrated,max_entries_in_mem) 
+        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, trigger) 
 
 
 

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -1,63 +1,63 @@
-import ROOT 
+import ROOT
 import mattak.backends.pyroot.mattakloader
 import mattak.Dataset
-import typing
+from typing import Sequence, Union, Tuple, Optional, Callable
 import numpy
 
-try:  
+try:
     import cppyy.ll
 
-#work around a weird issue that happens on some systems  
-#for some reason, in some configurations it  doesn't detect free in the global namespace. 
-#So we'll define a different function in the global namespace with a super creative name 
-#that does the same thing as free then set it equal to free. 
-except AttributeError: 
-    import cppyy 
-    cppyy.cppdef("void freee(void *p) { free(p); }") 
-    cppyy.gbl.free = cppyy.gbl.freee 
-    import cppyy.ll 
+#work around a weird issue that happens on some systems
+#for some reason, in some configurations it  doesn't detect free in the global namespace.
+#So we'll define a different function in the global namespace with a super creative name
+#that does the same thing as free then set it equal to free.
+except AttributeError:
+    import cppyy
+    cppyy.cppdef("void freee(void *p) { free(p); }")
+    cppyy.gbl.free = cppyy.gbl.freee
+    import cppyy.ll
 
 
-cppyy.cppdef(" bool is_nully(void *p) { return !p; }"); 
+cppyy.cppdef(" bool is_nully(void *p) { return !p; }");
 
 
-def isNully(p): 
-    return p is None or ROOT.AddressOf(p) == 0 or  cppyy.gbl.is_nully(p) 
+def isNully(p):
+    return p is None or ROOT.AddressOf(p) == 0 or  cppyy.gbl.is_nully(p)
 
-class Dataset(mattak.Dataset.AbstractDataset): 
+class Dataset(mattak.Dataset.AbstractDataset):
 
-    def __init__(self, station : int, run : int, data_dir : str, verbose: bool = False, skip_incomplete: bool = True): 
+    def __init__(self, station : int, run : int, data_dir : str, verbose: bool = False, skip_incomplete: bool = True):
 
-        #special case where we load a directory instead of a station/run 
-        if station == 0 and run == 0: 
+        #special case where we load a directory instead of a station/run
+        if station == 0 and run == 0:
             if verbose:
-                print("Trying to load data dir!") 
-            self.ds = ROOT.mattak.Dataset() 
-            self.ds.loadDir(data_dir, skip_incomplete) 
+                print("Trying to load data dir!")
+            self.ds = ROOT.mattak.Dataset()
+            self.ds.loadDir(data_dir, skip_incomplete)
             self.station = self.ds.header().station_number
             self.run = self.ds.header().run_number
 
-            if verbose: 
+            if verbose:
                 print("We think we found station %d run %d" % (self.station,self.run))
 
-        else: 
-            self.ds = ROOT.mattak.Dataset(station, run, ROOT.nullptr, data_dir, skip_incomplete) 
+        else:
+            self.ds = ROOT.mattak.Dataset(station, run, ROOT.nullptr, data_dir, skip_incomplete)
             self.station = station
-            self.run = run 
+            self.run = run
         self.data_dir = data_dir
-        self.setEntries(0) 
+        self.setEntries(0)
 
-    def N(self) -> int: 
-        return self.ds.N() 
+    def N(self) -> int:
+        return self.ds.N()
 
-    def _eventInfo(self, i : int) -> typing.Optional[mattak.Dataset.EventInfo]:
+    def _eventInfo(self, i : int) -> Optional[mattak.Dataset.EventInfo]:
         #TODO: handle this in C++ code if it's too slow in Python
-        if not self.ds.setEntry(i): 
-            return None 
-        hdr = self.ds.header() 
+        if not self.ds.setEntry(i):
+            return None
+        hdr = self.ds.header()
 
-        assert( hdr.station_number == self.station)
-        assert (hdr.run_number == self.run) 
+        assert(hdr.station_number == self.station)
+        assert(hdr.run_number == self.run)
         station = hdr.station_number
         run = hdr.run_number
         eventNumber = hdr.event_number
@@ -67,88 +67,89 @@ class Dataset(mattak.Dataset.AbstractDataset):
         if (hdr.trigger_info.radiant_trigger):
             which = hdr.trigger_info.which_radiant_trigger
             if which == -1:
-                which = "X" 
+                which = "X"
             triggerType = "RADIANT" + str(which)
         elif hdr.trigger_info.lt_trigger:
-            triggerType = "LT" 
+            triggerType = "LT"
         elif hdr.trigger_info.force_trigger:
-            triggerType = "FORCE" 
+            triggerType = "FORCE"
         elif hdr.trigger_info.pps_trigger:
-            triggerType = "PPS" 
+            triggerType = "PPS"
 
         pps = hdr.pps_num
         sysclk = hdr.sysclk
-        sysclkLastPPS = ( hdr.sysclk_last_pps, hdr.sysclk_last_last_pps) 
+        sysclkLastPPS = ( hdr.sysclk_last_pps, hdr.sysclk_last_last_pps)
         radiantStartWindows = numpy.frombuffer( cppyy.ll.cast['uint8_t*'](hdr.trigger_info.radiant_info.start_windows), dtype='uint8', count=24*2).reshape(24,2)
         sampleRate = 3.2 #if ( ROOT.AddressOf(self.ds.info()) ==0 or self.ds.info().radiant_sample_rate == 0)  else self.ds.info().radiant_sample_rate/1000.
 
 
-        return mattak.Dataset.EventInfo(eventNumber = eventNumber, 
-                                        station = station, 
-                                        run = run, 
-                                        readoutTime=readoutTime, 
-                                        triggerTime=triggerTime, 
-                                        triggerType=triggerType, 
-                                        sysclk=sysclk, 
-                                        sysclkLastPPS=sysclkLastPPS, 
-                                        pps=pps, 
+        return mattak.Dataset.EventInfo(eventNumber = eventNumber,
+                                        station = station,
+                                        run = run,
+                                        readoutTime=readoutTime,
+                                        triggerTime=triggerTime,
+                                        triggerType=triggerType,
+                                        sysclk=sysclk,
+                                        sysclkLastPPS=sysclkLastPPS,
+                                        pps=pps,
                                         radiantStartWindows = radiantStartWindows,
                                         sampleRate = sampleRate)
 
 
-    def eventInfo(self) -> typing.Union[typing.Optional[mattak.Dataset.EventInfo],typing.Sequence[typing.Optional[mattak.Dataset.EventInfo]]]: 
+    def eventInfo(self) -> Union[Optional[mattak.Dataset.EventInfo],Sequence[Optional[mattak.Dataset.EventInfo]]]:
 
         if self.multiple:
-            infos = [] 
+            infos = []
             for i in range(self.first, self.last):
                 infos.append(self._eventInfo(i))
-            return infos 
+            return infos
 
         return self._eventInfo(self.entry)
 
-    def _wfs(self, i : int, calibrated: bool = False): 
+    def _wfs(self, i : int, calibrated: bool = False):
         self.ds.setEntry(i)
         wf = self.ds.calibrated() if calibrated else self.ds.raw()
-        if isNully(wf): 
-            return None 
+        if isNully(wf):
+            return None
         return numpy.frombuffer(cppyy.ll.cast['double*' if calibrated else 'int16_t*'](wf.radiant_data), dtype = 'float64' if calibrated else 'int16', count = 24*2048).reshape(24,2048)
 
 
-    def wfs(self, calibrated : bool=False) -> numpy.ndarray: 
+    def wfs(self, calibrated : bool=False) -> numpy.ndarray:
 
         # the simple case first
         if not self.multiple:
-            return self._wfs(self.entry, calibrated) 
+            return self._wfs(self.entry, calibrated)
 
-        if self.last - self.first < 0: 
-            return None 
-        
+        if self.last - self.first < 0:
+            return None
+
         out = numpy.zeros((self.last - self.first, 24, 2048), dtype= 'float64' if calibrated else 'int16')
         for entry in range(self.first, self.last):
             this_wfs = self._wfs(entry, calibrated)
-            if this_wfs is not None: 
-                out[entry-self.first][:][:] = this_wfs 
+            if this_wfs is not None:
+                out[entry-self.first][:][:] = this_wfs
 
         return out
 
-    # ignore max_in_mem since it doesn't save much time for us... 
-    def _iterate(self, start, stop, calibrated, max_in_mem, trigger=None) -> typing.Tuple[mattak.Dataset.EventInfo, numpy.ndarray]:
-        
-        if trigger is not None:
+    # ignore max_in_mem since it doesn't save much time for us...
+    def _iterate(self, start, stop, calibrated, max_in_mem,
+                 selector: Optional[Callable[[mattak.Dataset.EventInfo], bool]] = None) -> Tuple[mattak.Dataset.EventInfo, numpy.ndarray]:
+
+        if selector is not None:
             for i in range(start, stop):
                 evinfo = self._eventInfo(i)
-                if evinfo.triggerType == trigger:
+                if selector(evinfo):
                     yield evinfo, self._wfs(i, calibrated)
         else:
             for i in range(start, stop):
                 yield self._eventInfo(i), self._wfs(i, calibrated)
-        return 
-       
+        return
 
 
 
 
-    
+
+
 
 
 

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -5,22 +5,23 @@ import configparser
 
 import mattak.Dataset
 import typing
-from typing import Union,List
+from typing import Union, Tuple, Optional, Callable, Sequence
 import numpy
 
 
-waveform_tree_names = ["waveforms","wfs","wf","waveform"]
-header_tree_names = ["hdr","header","hd","hds","headers"] 
+waveform_tree_names = ["waveforms", "wfs", "wf", "waveform"]
+header_tree_names = ["hdr", "header", "hd", "hds", "headers"]
 
-class Dataset ( mattak.Dataset.AbstractDataset):
+class Dataset(mattak.Dataset.AbstractDataset):
 
-    def __init__(self, station : int, run : int, data_dir : str, verbose : bool = False, skip_incomplete : bool = True): 
+    def __init__(self, station : int, run : int, data_dir : str, verbose : bool = False,
+                 skip_incomplete : bool = True):
 
         # special case where we load a directory instead of a station/run
         if station == 0 and run == 0: 
             self.rundir = data_dir
         else: 
-            self.rundir = "%s/station%d/run%d" % (data_dir,station,run)
+            self.rundir = "%s/station%d/run%d" % (data_dir, station, run)
 
         self.skip_incomplete = skip_incomplete 
         # this duplicates a bunch of C++ code in mattak::Dataset
@@ -116,7 +117,7 @@ class Dataset ( mattak.Dataset.AbstractDataset):
 
 
 
-    def eventInfo(self) -> Union[typing.Optional[mattak.Dataset.EventInfo],typing.Sequence[typing.Optional[mattak.Dataset.EventInfo]]]: 
+    def eventInfo(self) -> Union[Optional[mattak.Dataset.EventInfo],Sequence[Optional[mattak.Dataset.EventInfo]]]: 
         station = self._hds['station_number'].array(entry_start = self.first, entry_stop = self.last)
         run = self._hds['run_number'].array(entry_start = self.first, entry_stop = self.last)
         eventNumber = self._hds['event_number'].array(entry_start = self.first, entry_stop = self.last)
@@ -211,7 +212,8 @@ class Dataset ( mattak.Dataset.AbstractDataset):
         return None if w is None else w[0] 
         
 
-    def _iterate(self, start, stop, calibrated, max_in_mem, trigger=None) -> typing.Tuple[mattak.Dataset.EventInfo, numpy.ndarray]:
+    def _iterate(self, start, stop, calibrated, max_in_mem,
+                 selector: Optional[Callable[[mattak.Dataset.EventInfo], bool]] = None) -> Tuple[mattak.Dataset.EventInfo, numpy.ndarray]:
 
         current_start = -1 
         current_stop = -1
@@ -232,8 +234,8 @@ class Dataset ( mattak.Dataset.AbstractDataset):
 
             rel_i = i - current_start
             i += 1
-            if trigger is not None:
-                if e[rel_i].triggerType == trigger:
+            if selector is not None:
+                if selector(e[rel_i]):
                     yield e[rel_i], w[rel_i]
             else:
                 yield e[rel_i], w[rel_i]

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -211,7 +211,7 @@ class Dataset ( mattak.Dataset.AbstractDataset):
         return None if w is None else w[0] 
         
 
-    def _iterate(self, start, stop, calibrated,  max_in_mem) -> typing.Tuple[mattak.Dataset.EventInfo, numpy.ndarray]:
+    def _iterate(self, start, stop, calibrated, max_in_mem, trigger=None) -> typing.Tuple[mattak.Dataset.EventInfo, numpy.ndarray]:
 
         current_start = -1 
         current_stop = -1
@@ -230,9 +230,13 @@ class Dataset ( mattak.Dataset.AbstractDataset):
                 e = self.eventInfo()
                 self.setEntries(preserve_entries) # hide that we're modifying these 
 
-            rel_i = i -current_start
-            i+=1
-            yield (e[rel_i], w[rel_i])
+            rel_i = i - current_start
+            i += 1
+            if trigger is not None:
+                if e[rel_i].triggerType == trigger:
+                    yield e[rel_i], w[rel_i]
+            else:
+                yield e[rel_i], w[rel_i]
 
  
 

--- a/tests/test_dataset_filter.py
+++ b/tests/test_dataset_filter.py
@@ -1,0 +1,25 @@
+import mattak.Dataset
+import time
+
+d = mattak.Dataset.Dataset(23, 999, None, verbose=True)
+print(d.N())
+
+tigger_filter = lambda event_info: event_info.triggerType == "FORCE"
+time_filter = lambda event_info: 1663968535 < event_info.triggerTime < 1663968971
+
+start = time.time()
+d.setEntries((0, d.N()))
+for ev in d.iterate(selector=tigger_filter):
+    ei, wfs = ev
+    print(ei.triggerType)
+
+d.setEntries((0, d.N()))
+for ev in d.iterate(selector=time_filter):
+    ei, wfs = ev
+    print(ei.triggerTime)
+
+end = time.time()
+print ("time:", end - start)
+
+
+


### PR DESCRIPTION
Hi @cozzyd,

do you like this kind of feature? I think it would be useful. I am not sure if my implementation is the most elegant and efficient. 

However I ran a little speed test with the following code:
```
    start = time.time() 
    for _ in range(100):
        d.setEntries((0, d.N()))
        for ev in d.iterate(trigger="FORCE"): 
            ei, wfs = ev
            # print(ei.triggerType)
    end = time.time() 
    print ("time:", end-start)
```

On the main branch pyroot took 55s and uproot 29s. On this branch it took with pyroot 30s and with uproot 29s. (Of course with the main branch you actually access more events).
(The reason why uproot does get faster is also pretty obvious, maybe we can improve it)...