### PR TITLE
Refactor dataset._iterate from uproot backend for better readablity

### DIFF
--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -217,7 +217,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
                  selector: Optional[Callable[[mattak.Dataset.EventInfo], bool]] = None) -> Tuple[mattak.Dataset.EventInfo, numpy.ndarray]:
 
         # determine in how many batches we want to access the data given how much events we want to load into the RAM at once
-        n_batches = math.ceil((stop - start) // max_in_mem)
+        n_batches = math.ceil((stop - start) / max_in_mem)
 
         for i_batch in range(n_batches):
 

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -7,6 +7,7 @@ import mattak.Dataset
 import typing
 from typing import Union, Tuple, Optional, Callable, Sequence
 import numpy
+import math
 
 
 waveform_tree_names = ["waveforms", "wfs", "wf", "waveform"]
@@ -216,7 +217,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
                  selector: Optional[Callable[[mattak.Dataset.EventInfo], bool]] = None) -> Tuple[mattak.Dataset.EventInfo, numpy.ndarray]:
 
         # determine in how many batches we want to access the data given how much events we want to load into the RAM at once
-        n_batches = (stop - start) // max_in_mem + 1
+        n_batches = math.ceil((stop - start) // max_in_mem)
 
         for i_batch in range(n_batches):
 


### PR DESCRIPTION
Hey @cozzyd, this PR should not change the functionality nor improve performance (should be ~ unchanged), its only for readability because I had a really hard time understanding the old function. I tested the new iterate by comparing the output with the old iterator for 1 file and different values for `max_in_mem` (only checked the event numbers). Is that sufficient? Did I understand the idea of the original function correct?