### PR TITLE
Add interface function

### DIFF
--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -105,7 +105,7 @@ class AbstractDataset(ABC):
     
     def get_selected_wfs(self, selector: Callable[[EventInfo], bool], calibrated : bool = False) -> Optional[numpy.ndarray]:
         """ Convenience interface to use selector """
-        return numpy.array([wf for _, wf in self.iterate(selector=selector)])
+        return numpy.array([wf for _, wf in self.iterate(start=self.start, stop=self.stop, selector=selector)])
 
 
 def Dataset(station : int, run : int, data_dir : str = None, backend : str= "auto", verbose : bool = False, skip_incomplete : bool = True) -> Optional[AbstractDataset]:

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -102,6 +102,10 @@ class AbstractDataset(ABC):
             Depending on what was passed to setEntries, this may be a single waveform or many
         """
         pass
+    
+    def get_selected_wfs(self, selector: Callable[[EventInfo], bool], calibrated : bool = False) -> Optional[numpy.ndarray]:
+        """ Convenience interface to use selector """
+        return numpy.array([wf for _, wf in self.iterate(selector=selector)])
 
 
 def Dataset(station : int, run : int, data_dir : str = None, backend : str= "auto", verbose : bool = False, skip_incomplete : bool = True) -> Optional[AbstractDataset]:


### PR DESCRIPTION
Allows a similar interface to `d.wfs()`:

```
d.setEntries((0, d.N()))
wfs = d.get_selected_wfs(tigger_filter)
```