### PR TITLE
type casting of waveforms in python API

### DIFF
--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -99,7 +99,7 @@ class AbstractDataset(ABC):
         pass
 
     @abstractmethod
-    def wfs(self, calibrated : bool = False, wanted_type : Optional[typing.Type] = numpy.float32) -> Optional[numpy.ndarray]:
+    def wfs(self, calibrated : bool = False, wanted_type : Optional[typing.Type] = numpy.float64) -> Optional[numpy.ndarray]:
         """ Get select waveform(s).
             Depending on what was passed to setEntries, this may be a single waveform or many. 
             

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -99,9 +99,14 @@ class AbstractDataset(ABC):
         pass
 
     @abstractmethod
-    def wfs(self, calibrated : bool = False) -> Optional[numpy.ndarray]:
+    def wfs(self, calibrated : bool = False, wanted_type : Optional[typing.Type] = numpy.float32) -> Optional[numpy.ndarray]:
         """ Get select waveform(s).
-            Depending on what was passed to setEntries, this may be a single waveform or many
+            Depending on what was passed to setEntries, this may be a single waveform or many. 
+            
+            If you ask for calibrated waveforms, they will be calibrated (to the best of our current ability). 
+
+            The type of the numpy arrray will be coerced to the wanted_type (unless you set it to None, and then it will be whatever it comes out as. 
+
         """
         pass
     

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -253,7 +253,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
         elif not self.multiple: 
             if self.first in self.events_with_waveforms: 
                 idx = self.events_with_waveforms[self.first]
-                w = self._wfs['radiant_data[24][2048]'].array(entry_start=idx, entry_stop=idx+1, library='np').astype(wanted_type, copy=False)
+                w = self._wfs['radiant_data[24][2048]'].array(entry_start=idx, entry_stop=idx+1, library='np')
                 if wanted_type is not None: 
                     w = w.astype(wanted_type, copy=False)
         else: 

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -241,7 +241,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
     def N(self) -> int: 
         return self._hds.num_entries
 
-    def wfs(self, calibrated : bool = False, wanted_type : Optional[typing.Type] = numpy.float32) -> Optional[numpy.ndarray]: 
+    def wfs(self, calibrated : bool = False, wanted_type : Optional[typing.Type] = numpy.float64) -> Optional[numpy.ndarray]: 
         # assert(not calibrated) # not implemented yet 
 
         w = None 


### PR DESCRIPTION
int16 numpy arrays can behave unexpectedly (e.g. easy to accidentally overflow) and in most cases, one will want to do something with the waveforms that results in them being converted to floatings anyway. 

I attempted to add some control over the type returned by wfs( ) in the Python API by adding a wanted_type argument. 

Right now, this defaults to float64, but perhaps it should be float32 (currently, the C++ calibrated waveforms are 64-bit floats, though perhaps they shouldn't be?). For time-domain stuff, float32 is probably fine, but when you do an FFT it will get converted to a float64 anyway, I think, so adding this extra step may not be worth the memory savings? Either way the user has control...

If the user passes None to the wanted_type, it will behave as before. 
