### PR TITLE
Fixing bug in VoltageCalibration

### DIFF
--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -61,13 +61,15 @@ class Dataset(mattak.Dataset.AbstractDataset):
                 self.rundir = f"{data_path}/station{station}/run{run}"
                 self.ds.loadRun(station, run, opt)
 
-        if not isNully(voltage_calibration):
+        if isinstance(voltage_calibration, str) or not isNully(voltage_calibration):
+            # the voltage calibration has to be set as member variable. Otherwise the pointer would get deleted to early.
             if isinstance(voltage_calibration, str):
-                vc = ROOT.mattak.VoltageCalibration()
-                vc.readFitCoeffsFromFile(voltage_calibration)
-                voltage_calibration = vc
+                self.vc = ROOT.mattak.VoltageCalibration()
+                self.vc.readFitCoeffsFromFile(voltage_calibration)
+            else:
+                self.vc = voltage_calibration
 
-            self.ds.setCalibration(voltage_calibration)
+            self.ds.setCalibration(self.vc)
             self.has_calib = True
         else:
             self.has_calib = False

--- a/src/VoltageCalibration.cc
+++ b/src/VoltageCalibration.cc
@@ -14,12 +14,15 @@
 
 static double evalPars(double x, int order, const double * p)
 {
+  // calculate a polynominal of n order backwards
+  // a_n = p_n; a_n-1 = a_n * x + p_n-1; ...
   double ans = p[order];
   int i = order - 1;
   while (i >= 0)
   {
     ans = x * ans + p[i--];
   }
+
   return ans;
 }
 
@@ -1076,7 +1079,8 @@ double * mattak::applyVoltageCalibration (int nSamples_wf, const int16_t * in, d
 
     isamp_lab4 = isamp_A + isamp_B;
 
-    const double *params = packed_fit_params + isamp_lab4 * (fit_order+1);
+    // creating a pointer which points to the first parameter of this particular sample
+    const double *params = packed_fit_params + isamp_lab4 * (fit_order + 1);
 
     double adc = in[i];
     if (isUsingResid)

--- a/src/VoltageCalibration.cc
+++ b/src/VoltageCalibration.cc
@@ -1057,12 +1057,17 @@ double * mattak::applyVoltageCalibration (int N, const int16_t * in, double * ou
   int nSamplesPerGroup = mattak::k::num_radiant_samples;
   int nWindowsPerGroup = mattak::k::radiant_windows_per_buffer;
   int i = 0;
-  int isamp;
+  int isamp, isamp_A, isamp_B;
 
   if (isOldFirmware)
   {
     nSamplesPerGroup /= 2;
     nWindowsPerGroup /= 2;
+    isamp_A = (start_window / nWindowsPerGroup) * nSamplesPerGroup;
+  }
+  else
+  {
+    isamp_A = (start_window >= nWindowsPerGroup) * nSamplesPerGroup;
   }
 
   for (int iwindow = 0; iwindow < nwindows; iwindow++)
@@ -1071,16 +1076,9 @@ double * mattak::applyVoltageCalibration (int N, const int16_t * in, double * ou
 
     for (int k = 0; k < mattak::k::radiant_window_size; k++)
     {
-      if (isOldFirmware)
-      {
-        isamp = (start_window / nWindowsPerGroup) * nSamplesPerGroup;
-      }
-      else
-      {
-        isamp = (start_window >= nWindowsPerGroup) * nSamplesPerGroup;
-      }
+      isamp_B = (k + start_window * mattak::k::radiant_window_size) % nSamplesPerGroup;
 
-      isamp += (k + start_window * mattak::k::radiant_window_size) % nSamplesPerGroup;
+      isamp = isamp_A + isamp_B;
 
       const double *params = packed_fit_params + isamp * (fit_order+1);
 

--- a/src/VoltageCalibration.cc
+++ b/src/VoltageCalibration.cc
@@ -1077,23 +1077,18 @@ double * mattak::applyVoltageCalibration (int N, const int16_t * in, double * ou
 
     const double *params = packed_fit_params + isamp_lab4 * (fit_order+1);
 
-    double *residTablePerSamp_adc;
-    if (isUsingResid)
-    {
-      residTablePerSamp_adc = adcTablePerSample(fit_order, nResidPoints, params, packed_aveResid_volt, packed_aveResid_adc);
-    }
-
     double adc = in[i];
     if (isUsingResid)
     {
+      double *residTablePerSamp_adc;
+      residTablePerSamp_adc = adcTablePerSample(fit_order, nResidPoints, params, packed_aveResid_volt, packed_aveResid_adc);
       out[i] = adcToVolt(adc, nResidPoints, packed_aveResid_volt, residTablePerSamp_adc);
+      delete residTablePerSamp_adc;
     }
     else
     {
       out[i] = evalPars(adc, fit_order, params);
     }
-
-    delete residTablePerSamp_adc;
   }
 
   return out;

--- a/src/VoltageCalibration.cc
+++ b/src/VoltageCalibration.cc
@@ -2,11 +2,6 @@
 #include <iostream>
 #include <stdio.h>
 
-
-#ifdef MATTAK_VECTORIZE
-#include "vectorclass/vectorclass.h"
-#endif
-
 #ifdef LIBRNO_G_SUPPORT
 #include "rno-g.h"
 #endif
@@ -33,6 +28,7 @@ static double* adcTablePerSample(int order, int npoints, const double * par, con
 
   for (int i = 0; i < npoints; i++)
   {
+    // When we perform a calibration with residuals, we fit f(V) -> ADC
     adcTable[i] = evalPars(voltTable[i], order, par) + resid_adc[i];
   }
 
@@ -58,7 +54,7 @@ static double adcToVolt(double in_adc, int npoints, const double * voltTable, co
   }
   if (in_adc > adc_array[npoints-1])
   {
-    m = (volt_array[npoints-1] - volt_array[npoints-2])/(adc_array[npoints-1] - adc_array[npoints-2]);
+    m = (volt_array[npoints-1] - volt_array[npoints-2]) / (adc_array[npoints-1] - adc_array[npoints-2]);
     out_volt = volt_array[npoints-1] + (in_adc - adc_array[npoints-1]) * m;
     return out_volt;
   }
@@ -1092,6 +1088,7 @@ double * mattak::applyVoltageCalibration (int nSamples_wf, const int16_t * in, d
     }
     else
     {
+      // When we perform a calibration without residuals, we directly fit f(ADC) -> V
       out[i] = evalPars(adc, fit_order, params);
     }
   }

--- a/src/VoltageCalibration.cc
+++ b/src/VoltageCalibration.cc
@@ -1059,6 +1059,12 @@ double * mattak::applyVoltageCalibration (int N, const int16_t * in, double * ou
   int i = 0;
   int isamp;
 
+  if (isOldFirmware)
+  {
+    nSamplesPerGroup /= 2;
+    nWindowsPerGroup /= 2;
+  }
+
   for (int iwindow = 0; iwindow < nwindows; iwindow++)
   {
 #ifndef MATTAK_VECTORIZE
@@ -1067,8 +1073,6 @@ double * mattak::applyVoltageCalibration (int N, const int16_t * in, double * ou
     {
       if (isOldFirmware)
       {
-        nSamplesPerGroup /= 2;
-        nWindowsPerGroup /= 2;
         isamp = (start_window / nWindowsPerGroup) * nSamplesPerGroup;
       }
       else

--- a/src/mattak/VoltageCalibration.h
+++ b/src/mattak/VoltageCalibration.h
@@ -21,7 +21,7 @@ namespace mattak
   // @param N number of samples (must be multiple of window size!)
   // @param in the input (raw samples, pedestal subtracted)
   //
-  double * applyVoltageCalibration(int N, const int16_t * in, double * out, int start_window, bool isOldFirmware, int fit_order,
+  double * applyVoltageCalibration(int nSamples_wf, const int16_t * in, double * out, int start_window, bool isOldFirmware, int fit_order,
                         int nResidPoints, const double * packed_fit_params, bool isUsingResid, const double * packed_aveResid_volt, const double * packed_aveResid_adc);
 
 
@@ -56,9 +56,9 @@ namespace mattak
       const double * getFitCoeffs(int chan, int sample) const { return getPackedFitCoeffs(chan) + sample * (getFitOrder()+1); }
       double getFitCoeff(int chan, int sample, int coeff) const { return getFitCoeffs(chan,sample)[coeff]; }
       const double * getPackedFitCoeffs(int chan) const { return &fit_coeffs[chan][0]; }
-      double * apply(int chan, int N, const int16_t * in, int start_window, double * out = 0, bool isOldFirmware = false) const
+      double * apply(int chan, int nSamples_wf, const int16_t * in, int start_window, double * out = 0, bool isOldFirmware = false) const
       {
-        return applyVoltageCalibration(N, in, out, start_window, isOldFirmware, getFitOrder(), getNresidPoints(chan),
+        return applyVoltageCalibration(nSamples_wf, in, out, start_window, isOldFirmware, getFitOrder(), getNresidPoints(chan),
                                        getPackedFitCoeffs(chan), isResid(), getPackedAveResid_volt(chan), getPackedAveResid_adc(chan));
       }
       TH2S * makeHist(int channel) const;


### PR DESCRIPTION
Fixed the function for the waveform windows and the physical windows mappings. From a specific case to a general case, now the mapping subranges change depending on the input start_window. And also removed all the hard coding parts in that function.