### PR TITLE
import annotations from __future__ to prevent errors on python<3.9

### DIFF
--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -1,4 +1,5 @@
 ### Python dataset class, agnostic to backend
+from __future__ import annotations
 import os
 import glob
 import re

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import ROOT
 import mattak.backends.pyroot.mattakloader
 import mattak.Dataset

--- a/py/mattak/backends/uproot/voltage_calibration.py
+++ b/py/mattak/backends/uproot/voltage_calibration.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import mattak.Dataset
 
 from typing import Union, Optional


### PR DESCRIPTION
This only solves a problem in `voltage_calibration.py` currently, but I figured seeing as they are used in the other modules too, it's probably safer to use the 'future' type annotations everywhere. I did verify that this solves the `TypeError` in #50 on Python 3.7.

Fixes #50 