### PR TITLE
Use only python 3.6-compatible type annotations

### DIFF
--- a/py/mattak/backends/uproot/voltage_calibration.py
+++ b/py/mattak/backends/uproot/voltage_calibration.py
@@ -1,6 +1,6 @@
 import mattak.Dataset
 
-from typing import Union, Optional
+from typing import Union, Optional, List
 import numpy
 import uproot
 
@@ -128,7 +128,7 @@ class VoltageCalibration(object):
 
 
     def calibrate(self, waveform_array : numpy.ndarray, starting_window : Union[float, int],
-                  channels : Optional[list[int]] = None,
+                  channels : Optional[List[int]] = None,
                   fit_min : float = -1.3, fit_max : float = 0.7) -> numpy.ndarray:
         """
         The calibration function that transforms waveforms from ADC to voltage. Uses caching.


### PR DESCRIPTION
See discussion in #50 / #51 

In order to maintain compatibility with python 3.6, we can't use the current standard for type annotations by importing from `__future__`, so we'll have to make sure to only use python-3.6 compatible type annotations. These will be deprecated eventually, but not until [2025](https://peps.python.org/pep-0585/#implementation).

Closes #50 