### PR TITLE
workaround/fix for crash when reading samplerate if skip_incomplete is False

### DIFF
--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -129,7 +129,10 @@ class Dataset(mattak.Dataset.AbstractDataset):
         # the default value for the sampling rate (3.2 GHz) which is used
         # for data which does not contain this information in the waveform files
         # is set in the header fils Waveforms.h
-        sampleRate = self.ds.raw().radiant_sampling_rate / 1000
+        try:
+            sampleRate = self.ds.raw().radiant_sampling_rate / 1000
+        except ReferenceError:
+            sampleRate = None
 
         assert(hdr.station_number == self.station)
         assert(hdr.run_number == self.run)


### PR DESCRIPTION
Currently, when using the pyroot backend, if attempting to read in directories with the option `skip_incomplete=False`, the following error is raised:
```
---------------------------------------------------------------------------
ReferenceError                            Traceback (most recent call last)
Cell In[4], line 2
      1 import mattak.Dataset
----> 2 mattak.Dataset.Dataset(data_path=\"/home/sb/Python/scratch/data/inbox/station21/run1847\", skip_incomplete=False, backend='pyroot')

File ~/Python/.venv/nu-radio/lib/python3.10/site-packages/mattak/Dataset.py:262, in Dataset(station, run, data_path, backend, verbose, skip_incomplete, read_daq_status, read_run_info, preferred_file, voltage_calibration, cache_calibration, data_dir)
    260 elif backend == \"pyroot\":
    261     import mattak.backends.pyroot.dataset
--> 262     return mattak.backends.pyroot.dataset.Dataset(
    263         station, run, data_path, verbose=verbose, skip_incomplete=skip_incomplete, read_daq_status=read_daq_status,
    264         read_run_info=read_run_info, preferred_file=preferred_file, voltage_calibration=voltage_calibration,
    265         cache_calibration=cache_calibration)
    267 else:
    268     print(\"Unknown backend (known backends are \\\"uproot\\\" and \\\"pyroot\\\")\")

File ~/Python/.venv/nu-radio/lib/python3.10/site-packages/mattak/backends/pyroot/dataset.py:83, in Dataset.__init__(self, station, run, data_path, verbose, skip_incomplete, read_daq_status, read_run_info, preferred_file, voltage_calibration, cache_calibration)
     80 if verbose:
     81     print(\"Looking for a calibration file\")
---> 83 cal_file = mattak.Dataset.find_voltage_calibration_for_dataset(self)
     84 if cal_file is not None:
     85     if verbose:

File ~/Python/.venv/nu-radio/lib/python3.10/site-packages/mattak/Dataset.py:275, in find_voltage_calibration_for_dataset(dataset)
    273 \"\"\" Wrapper around find_voltage_calibration \"\"\"
    274 dataset.setEntries(0)
--> 275 return find_voltage_calibration(dataset.rundir, dataset.station, dataset.eventInfo().triggerTime)

File ~/Python/.venv/nu-radio/lib/python3.10/site-packages/mattak/backends/pyroot/dataset.py:187, in Dataset.eventInfo(self)
    183         infos.append(self._eventInfo(i))
    185     return infos
--> 187 return self._eventInfo(self.entry)

File ~/Python/.venv/nu-radio/lib/python3.10/site-packages/mattak/backends/pyroot/dataset.py:132, in Dataset._eventInfo(self, i)
    127     lowTrigThrs = None
    129 # the default value for the sampling rate (3.2 GHz) which is used
    130 # for data which does not contain this information in the waveform files
    131 # is set in the header fils Waveforms.h
--> 132 sampleRate = self.ds.raw().radiant_sampling_rate / 1000
    134 assert(hdr.station_number == self.station)
    135 assert(hdr.run_number == self.run)

ReferenceError: attempt to access a null-pointer
```

This only happens on the pyroot backend, preventing e.g. reading in eventInfo from the header files only; on the uproot backend, this works okay.

This PR provides a workaround rather than an actual fix for the problem; if the reviewer has more insight into how this _should_ be prevented they are welcome to suggest something better instead : )

MWE:
```
import mattak.Dataset
mattak.Dataset.Dataset(
    data_path="/home/sb/Python/scratch/data/inbox/station21/run1847", 
    skip_incomplete=False, backend='pyroot')
```