### PR TITLE
Hotfix/unpin awkward

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,4 @@ authors = [{name="Cosmin Deaconu, email=<cozzyd@kicp.uchicago.edu>"}]
 homepage = "https://github.com/RNO-G/mattak"
 readme = "README.md"
 description = "Mattak is (will eventually be) a multilingual package containing readers and helpers for RNO-G in C++, Python (via both uproot and PyROOT) and maybe even JS (via rootjs)."
-dependencies = ["numpy", "uproot", "awkward<2"]
+dependencies = ["numpy<2", "uproot", "awkward<2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,4 @@ authors = [{name="Cosmin Deaconu, email=<cozzyd@kicp.uchicago.edu>"}]
 homepage = "https://github.com/RNO-G/mattak"
 readme = "README.md"
 description = "Mattak is (will eventually be) a multilingual package containing readers and helpers for RNO-G in C++, Python (via both uproot and PyROOT) and maybe even JS (via rootjs)."
-dependencies = ["numpy<2", "uproot", "awkward<2"]
+dependencies = ["numpy", "uproot", "awkward"]


### PR DESCRIPTION
The tests were failing due to an incompatible combination of uproot/awkward and numpy (the new 2.0) release. It _seems_ the reason (which I can't recall) to pin `awkward<2` no longer applies, so rather than pinning numpy, I figured we can unpin awkward and allow the latest versions of all three.

I will make a similar PR to unpin awkward on NuRadioMC to (hopefully) prevent compatibility issues between the two.