### PR TITLE
Improve skip incomplete false uproot

### DIFF
--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -26,7 +26,7 @@ class EventInfo:
     sampleRate: Optional[float]  # Sample rate, in GSa/s
     radiantThrs: Optional[numpy.ndarray]
     lowTrigThrs: Optional[numpy.ndarray]
-    hasWaveforms: bool
+    hasWaveforms: bool = True
 
 
 class AbstractDataset(ABC):

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -26,6 +26,7 @@ class EventInfo:
     sampleRate: Optional[float]  # Sample rate, in GSa/s
     radiantThrs: Optional[numpy.ndarray]
     lowTrigThrs: Optional[numpy.ndarray]
+    hasWaveforms: bool
 
 
 class AbstractDataset(ABC):
@@ -84,6 +85,7 @@ class AbstractDataset(ABC):
 
     def iterate(self, start : int = 0, stop : Union[int, None] = None,
                 calibrated: bool = False, max_entries_in_mem : int = 256,
+                overwrite_skip_incomplete : Optional[bool] = None,
                 selectors: Optional[Union[Callable[[EventInfo], bool],
                                           Sequence[Callable[[EventInfo], bool]]]] = None) \
                 -> Generator[Tuple[Optional[EventInfo], Optional[numpy.ndarray]], None, None]:
@@ -105,7 +107,7 @@ class AbstractDataset(ABC):
         if stop < 0 or start > self.N():
             return
 
-        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, selectors)
+        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, overwrite_skip_incomplete, selectors)
 
     @abstractmethod
     def eventInfo(self) -> Union[Optional[EventInfo], Sequence[Optional[EventInfo]]]:

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -83,11 +83,11 @@ class AbstractDataset(ABC):
         """ implementation-defined part of iterator"""
         pass
 
-    def iterate(self, start : int = 0, stop : Union[int, None] = None,
-                calibrated: bool = False, max_entries_in_mem : int = 256,
-                overwrite_skip_incomplete : Optional[bool] = None,
-                selectors: Optional[Union[Callable[[EventInfo], bool],
-                                          Sequence[Callable[[EventInfo], bool]]]] = None) \
+    def iterate(
+            self, start : int = 0, stop : Union[int, None] = None,
+            calibrated: bool = False, max_entries_in_mem : int = 256,
+            selectors: Optional[Union[Callable[[EventInfo], bool], Sequence[Callable[[EventInfo], bool]]]] = None,
+            override_skip_incomplete : Optional[bool] = None) \
                 -> Generator[Tuple[Optional[EventInfo], Optional[numpy.ndarray]], None, None]:
         """ Iterate over events from start to stop, holding at most max_entries_in_mem in RAM.
             Returns a tuple of EventInfo and the event waveforms (potentially calibrated).
@@ -107,7 +107,7 @@ class AbstractDataset(ABC):
         if stop < 0 or start > self.N():
             return
 
-        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, overwrite_skip_incomplete, selectors)
+        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, selectors, override_skip_incomplete=override_skip_incomplete)
 
     @abstractmethod
     def eventInfo(self) -> Union[Optional[EventInfo], Sequence[Optional[EventInfo]]]:

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -219,14 +219,18 @@ class Dataset(mattak.Dataset.AbstractDataset):
         return out
 
 
-    def _iterate(self, start : int, stop : int, calibrated : bool , max_in_mem : int,
-                 selectors: Optional[Union[Callable[[mattak.Dataset.EventInfo], bool],
-                                           Sequence[Callable[[mattak.Dataset.EventInfo], bool]]]] = None) -> Generator[Tuple[Optional[mattak.Dataset.EventInfo], Optional[numpy.ndarray]],None,None]:
+    def _iterate(
+            self, start : int, stop : int, calibrated : bool , max_in_mem : int,
+            selectors: Optional[Union[Callable[[mattak.Dataset.EventInfo], bool], Sequence[Callable[[mattak.Dataset.EventInfo], bool]]]] = None,
+            override_skip_incomplete : Optional[bool] = None) -> Generator[Tuple[Optional[mattak.Dataset.EventInfo], Optional[numpy.ndarray]], None, None]:
+
+        if override_skip_incomplete is not None:
+            warnings.NotImplemented("`override_skip_incomplete` is not implemented for the pyroot backend")
 
         if selectors is not None:
             if not isinstance(selectors, (list, numpy.ndarray)):
                 selectors = [selectors]
-                
+
             for i in range(start, stop):
                 evinfo = self._eventInfo(i)
                 if evinfo is not None and numpy.all([selector(evinfo) for selector in selectors]):

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -228,10 +228,10 @@ class Dataset(mattak.Dataset.AbstractDataset):
 
             for i in range(start, stop):
                 evinfo = self._eventInfo(i)
+                wfs = self._wfs(i, calibrated)
+                if skip_incomplete and wfs is None:
+                    continue
                 if evinfo is not None and numpy.all([selector(evinfo) for selector in selectors]):
-                    wfs = self._wfs(i, calibrated)
-                    if skip_incomplete and wfs is None:
-                        continue
                     yield evinfo, wfs
         else:
             for i in range(start, stop):

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -229,7 +229,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             selectors: Optional[Union[Callable[[mattak.Dataset.EventInfo], bool], Sequence[Callable[[mattak.Dataset.EventInfo], bool]]]] = None,
             override_skip_incomplete : Optional[bool] = None) -> Generator[Tuple[Optional[mattak.Dataset.EventInfo], Optional[numpy.ndarray]], None, None]:
 
-        skip_incomplete = override_skip_incomplete or self.ds.options().partial_skip_incomplete
+        skip_incomplete = override_skip_incomplete or self.ds.getOpt().partial_skip_incomplete
 
         if selectors is not None:
             if not isinstance(selectors, (list, numpy.ndarray)):
@@ -248,4 +248,3 @@ class Dataset(mattak.Dataset.AbstractDataset):
                 if skip_incomplete and wfs is None:
                     continue
                 yield self._eventInfo(i), wfs
-

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -456,6 +456,10 @@ class Dataset(mattak.Dataset.AbstractDataset):
             # this is intransparent for the outside world and has to be reverted
             self.setEntries(original_entry)
 
+            # can happen if we skip incomplete events
+            if wfs is None:
+                continue
+
             for e, w in zip(es, wfs):
                 if selectors is not None:
                     if numpy.all([selector(e) for selector in selectors]):

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -187,7 +187,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             if not self.skip_incomplete:
                 wfs_included = self._wfs['event_number'].array()
                 self.events_with_waveforms = {ev: idx for idx, ev in enumerate(wfs_included)}
-                print(self.events_with_waveforms)
+
                 self.full_head_file = uproot.open(f"{self.rundir}/headers.root")
                 self.full_head_tree,_ = read_tree(self.full_head_file, header_tree_names)
 

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -412,16 +412,17 @@ class Dataset(mattak.Dataset.AbstractDataset):
             w = w[:, channels]
             starting_window = starting_window[:, channels]
 
-        # calibration
-        starting_window = starting_window[:, :, 0]
-        if calibrated:
-            # this can run now both normal and raw calibration
-            w = numpy.array([self.vc(ele, starting_window[i]) for i, ele in enumerate(w)])
+        if w is not None:
+            # calibration
+            starting_window = starting_window[:, :, 0]
+            if calibrated:
+                # this can run now both normal and raw calibration
+                w = numpy.array([self.vc(ele, starting_window[i]) for i, ele in enumerate(w)])
 
-        w = numpy.asarray(w, dtype=float)
+            w = numpy.asarray(w, dtype=float)
 
-        if self.multiple:
-            return w
+            if self.multiple:
+                return w
 
         return None if w is None else w[0]
 


### PR DESCRIPTION
Thos PR does two thinks:
First, it adds some fixes such you can use the uproot backend with `skip_incomplete=False` (apparently this is not tested via the CI)
Second, it implements the option to overwrite `skip_incomplete`. I am not sure if the implementation I found is the cleanest and nor if it make the code unreadable or just very hard to understand. I am happy for any suggestion how to make this better. The motivation for this is the following: When I run analyse satellite data I want excess to all data to inspect, e.g., the trigger dependent trigger rate. However, with the same dataset I also want to look at waveforms. However, currently for every event without waveform we create an one and fill it with zeros. This make the hole process quite slow and memory hungry. With this option you skip that step and only return the actual waveforms.