### PR TITLE
Problem loading pyroot backend mattakloader

### DIFF
--- a/py/mattak/backends/pyroot/mattakloader.py
+++ b/py/mattak/backends/pyroot/mattakloader.py
@@ -27,23 +27,23 @@ else:
     libmattakName = 'libmattak.so'
 
 if not loaded:
-    if not silent_load(libmattakName):
+    if silent_load(libmattakName) > -1:
         loaded_path = "LD_LIBRARY_PATH"
         # print('Successfully found ' + libmattakName + ' in LD_LIBRARY_PATH')
         loaded = True
-    elif not silent_load('build/'+libmattakName):
+    elif silent_load('build/'+libmattakName) > -1:
         # print('Successsfully found ' + libmattakName + ' in build')
         loaded_path = "build"
         loaded = True
     else:
         ROOT.gInterpreter.AddIncludePath(mattak_include_path)
-        if not silent_load(os.path.join(mattak_path, libmattakName)):
+        if silent_load(os.path.join(mattak_path, libmattakName)) > -1:
             print('Successsfully found ' + libmattakName + ' in ' + mattak_path)
             loaded_path = mattak_path
             loaded = True
         else:
           for path in sys.path:
-             if not silent_load(path + '/mattak/backends/pyroot/'+libmattakName):
+             if silent_load(path + '/mattak/backends/pyroot/'+libmattakName) > -1:
                  # print('Successsfully found ' + libmattakName + ' in ', path)
                  loaded_path = path
                  loaded = True

--- a/py/mattak/backends/pyroot/mattakloader.py
+++ b/py/mattak/backends/pyroot/mattakloader.py
@@ -2,6 +2,9 @@ import ROOT
 import sys
 import platform
 import os
+import logging
+logger = logging.getLogger(__name__)
+logging.basicConfig(level = logging.DEBUG)
 from mattak import __path__ as mattak_path
 
 # this is where pip puts the compiled files
@@ -26,25 +29,34 @@ if 'macOS' in currentPlatform:
 else:
     libmattakName = 'libmattak.so'
 
+try:
+    import ROOT
+    ds = ROOT.mattak.Dataset()
+    logger.debug("Found libmattak to be already loaded.")
+    loaded = True
+except:
+    pass
+
+
 if not loaded:
-    if silent_load(libmattakName) > -1:
+    if not silent_load(libmattakName):
         loaded_path = "LD_LIBRARY_PATH"
-        # print('Successfully found ' + libmattakName + ' in LD_LIBRARY_PATH')
+        logger.debug('Successfully found ' + libmattakName + ' in LD_LIBRARY_PATH')
         loaded = True
-    elif silent_load('build/'+libmattakName) > -1:
-        # print('Successsfully found ' + libmattakName + ' in build')
+    elif not silent_load('build/'+libmattakName):
+        logger.debug('Successsfully found ' + libmattakName + ' in build')
         loaded_path = "build"
         loaded = True
     else:
         ROOT.gInterpreter.AddIncludePath(mattak_include_path)
-        if silent_load(os.path.join(mattak_path, libmattakName)) > -1:
-            print('Successsfully found ' + libmattakName + ' in ' + mattak_path)
+        if not silent_load(os.path.join(mattak_path, libmattakName)):
+            logger.debug('Successsfully found ' + libmattakName + ' in ' + mattak_path)
             loaded_path = mattak_path
             loaded = True
         else:
           for path in sys.path:
-             if silent_load(path + '/mattak/backends/pyroot/'+libmattakName) > -1:
-                 # print('Successsfully found ' + libmattakName + ' in ', path)
+             if not silent_load(path + '/mattak/backends/pyroot/'+libmattakName):
+                 logger.debug('Successsfully found ' + libmattakName + ' in ', path)
                  loaded_path = path
                  loaded = True
                  break

--- a/py/mattak/backends/pyroot/mattakloader.py
+++ b/py/mattak/backends/pyroot/mattakloader.py
@@ -4,7 +4,6 @@ import platform
 import os
 import logging
 logger = logging.getLogger(__name__)
-logging.basicConfig(level = logging.DEBUG)
 from mattak import __path__ as mattak_path
 
 # this is where pip puts the compiled files
@@ -30,13 +29,11 @@ else:
     libmattakName = 'libmattak.so'
 
 try:
-    import ROOT
-    ds = ROOT.mattak.Dataset()
-    logger.debug("Found libmattak to be already loaded.")
-    loaded = True
+    if ROOT.mattak is not None:
+        logger.debug("Found libmattak to be already loaded.")
+        loaded = True
 except:
     pass
-
 
 if not loaded:
     if not silent_load(libmattakName):


### PR DESCRIPTION
The mattakloader in the pyroot backend crashes when the mattak library was previously loaded in a different script. e.g. running ROOT.gSystem.Load("libmattak.so") before trying to initialize mattak.Dataset() with the pyroot backend. This because silent_load returns 1 when the library is already loaded. This PR tries to fix this by checking whether libmattak is already loaded in the beginning of mattakloader.py.