### PR TITLE
ROOT and python garbage collector

### DIFF
--- a/scripts/convert_bias_scan_to_calibration.py
+++ b/scripts/convert_bias_scan_to_calibration.py
@@ -71,6 +71,7 @@ if __name__ == '__main__':
         vref = args.vref
 
     vc = ROOT.mattak.VoltageCalibration(args.bias_scan, vref)
+    ROOT.SetOwnership(vc, False)
 
     # Jump into the directory in which to store the calibration
     if args.destination_folder is not None:


### PR DESCRIPTION
@fschlueter @CamphynR 

Without this change the script is producing segfaults in the `VoltageCalibration` destructor, _if_ ROOT files are being read (at least in my installation). Reading from raw data seems fine, however.