### PR TITLE
try to speed up eventinfo only reading

### DIFF
--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -185,7 +185,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             sampleRate=sampleRate,
             radiantThrs=radiantThrs,
             lowTrigThrs=lowTrigThrs,
-            hasWaveforms=not isNully(self.ds.wfTree()),
+            hasWaveforms= self.ds.rawAvailable()
             readoutDelay=readout_delay)
 
 

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -185,7 +185,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             sampleRate=sampleRate,
             radiantThrs=radiantThrs,
             lowTrigThrs=lowTrigThrs,
-            hasWaveforms= self.ds.rawAvailable()
+            hasWaveforms= self.ds.rawAvailable(),
             readoutDelay=readout_delay)
 
 

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -140,14 +140,8 @@ class Dataset(mattak.Dataset.AbstractDataset):
             radiantThrs = numpy.array(daq_status.radiant_thresholds)
             lowTrigThrs = numpy.array(daq_status.lt_trigger_thresholds)
 
-        # the default value for the sampling rate (3.2 GHz) which is used
-        # for data which does not contain this information in the waveform files
-        # is set in the header fils Waveforms.h
-        try:
-            sampleRate = self.ds.raw().radiant_sampling_rate / 1000
-        except ReferenceError:
-            # Fall back to runinfo (as in uproot backend)
-            sampleRate = self.ds.info().radiant_sample_rate / 1000
+        # now use Dataset's faster sample rate getter
+        sampleRate = self.ds.radiantSampleRate() / 1000
 
         hdr = self.ds.header()
 
@@ -174,7 +168,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             dtype='uint8', count=self.NUM_CHANNELS * 2).reshape(self.NUM_CHANNELS, 2))
 
         readout_delay = numpy.copy(numpy.around(numpy.frombuffer(
-            cppyy.ll.cast['float*'](self.ds.raw().digitizer_readout_delay_ns),
+            cppyy.ll.reinterpret_cast['float*'](self.ds.radiantReadoutDelays()),
             dtype = numpy.float32, count=self.NUM_CHANNELS)))
 
         return mattak.Dataset.EventInfo(
@@ -191,7 +185,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             sampleRate=sampleRate,
             radiantThrs=radiantThrs,
             lowTrigThrs=lowTrigThrs,
-            hasWaveforms=not isNully(self.ds.raw()),
+            hasWaveforms=not isNully(self.ds.wfTree()),
             readoutDelay=readout_delay)
 
 

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -321,23 +321,23 @@ class Dataset(mattak.Dataset.AbstractDataset):
 
         infos = []
         info = None  # if range(0)
-        for i, triggerInfoi in zip(range(self.last - self.first), triggerInfo):
+        for i, t_info in zip(range(self.last - self.first), triggerInfo):
 
             if override_skip_incomplete is not None and override_skip_incomplete:
                 if eventNumber[i] not in self.events_with_waveforms.keys():
                     continue
 
             triggerType  = "UNKNOWN"
-            if triggerInfoi['trigger_info.radiant_trigger']:
-                which = triggerInfoi['trigger_info.which_radiant_trigger']
+            if t_info['trigger_info.radiant_trigger']:
+                which = t_info['trigger_info.which_radiant_trigger']
                 if which == -1:
                     which = "X"
                 triggerType = "RADIANT" + str(which)
-            elif triggerInfoi['trigger_info.lt_trigger']:
+            elif t_info['trigger_info.lt_trigger']:
                 triggerType = "LT"
-            elif triggerInfoi['trigger_info.force_trigger']:
+            elif t_info['trigger_info.force_trigger']:
                 triggerType = "FORCE"
-            elif triggerInfoi['trigger_info.pps_trigger']:
+            elif t_info['trigger_info.pps_trigger']:
                 triggerType = "PPS"
 
             radiantThrs = None

--- a/src/mattak/Dataset.h
+++ b/src/mattak/Dataset.h
@@ -71,6 +71,7 @@ namespace mattak
       int loadDir(const char * dir);
       int loadCombinedFile(const char * file);
 
+      int currentEntry() const { return current_entry; }
 
       /**
        * Deprecated, kept for ABI compatibility
@@ -87,6 +88,13 @@ namespace mattak
 
       mattak::Header * header(bool force_reload = false);
       mattak::Waveforms * raw(bool force_reload = false);
+
+      // these methods are useful if you want to read waveform metadata without reading the waveforms
+      // if you are reading the waveforms, they are less efficient than getting what you want from raw
+      float radiantSampleRate(bool force_reload = false);
+      const float * radiantReadoutDelays(bool force_reload = false);  //size is mattak::k::num_radiant_channels, returning a float* since cppyyy doesn't seem to be able to deal with std::array properly
+      
+      
       mattak::CalibratedWaveforms * calibrated(bool force_reload = false); //will be nullptr if no calibration is passed
       mattak::DAQStatus * status(bool force_reload = false);
       mattak::RunInfo * info() const { return runinfo.ptr; }
@@ -129,17 +137,21 @@ namespace mattak
       static const char ** getDAQStatusTreeNames();
       static const char ** getPedestalTreeNames();
     private:
-
-
       tree_field<Waveforms> wf;
       tree_field<Header> hd;
       tree_field<DAQStatus> ds;
       tree_field<Pedestals> pd;
       file_field<RunInfo> runinfo;
+
+      tree_field<uint32_t> sample_rate;
+      tree_field<std::array<float,mattak::k::num_radiant_channels>> delays;
+      void setupRadiantMeta();
+
       field<CalibratedWaveforms> calib_wf;
 
       void unload();
       int current_entry = 0;
+
 
       bool full_dataset ;
       DatasetOptions opt;

--- a/src/mattak/Dataset.h
+++ b/src/mattak/Dataset.h
@@ -89,6 +89,14 @@ namespace mattak
       mattak::Header * header(bool force_reload = false);
       mattak::Waveforms * raw(bool force_reload = false);
 
+      // is the raw data available for currentEntry? (mostly used by PyROOT backend) 
+      bool rawAvailable(bool force_reload = false) 
+      {  
+        return  wf.tree && 
+         ( full_dataset || opt.partial_skip_incomplete || 
+           wf.tree->GetEntryNumberWithIndex(header(force_reload)->event_number) >=0); 
+      }
+
       // these methods are useful if you want to read waveform metadata without reading the waveforms
       // if you are reading the waveforms, they are less efficient than getting what you want from raw
       float radiantSampleRate(bool force_reload = false);


### PR DESCRIPTION
See https://github.com/RNO-G/mattak/issues/19

For now, this only improves performance for the PyROOT backend. It's a bit kludgey, but it does speed up reading eventinfos only by about a factor of 15 for me... 

The basic strategy is to avoid calling ds.raw() (which would load the waveforms) and instead use specialized access for only the portions of the waveform file we care about in the EventInfo .


