### PR TITLE
More tests

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -35,7 +35,7 @@ jobs:
       run: |
         wget https://rnog-data.zeuthen.desy.de/rnog_share/mattak_ci/station23.tar.gz
         mkdir -p tests/data
-        tar -xaf station23.tar.gz tests/data/
+        tar -xavf station23.tar.gz -C tests/data/
     - name: Get previous benchmark results
       uses: actions/cache/restore@v4
       with:

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -78,9 +78,11 @@ jobs:
         python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend pyroot --benchmark ${{ github.sha }}
     - name: Calibrate a sample file
       run: |
+        source root/bin/thisroot.sh
         python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend pyroot --calibrate -vc tests/data/station23/run325/volCalConsts_pol9_s11_1687936603-1687938078.root --benchmark ${{ github.sha }}
     - name: Read incomplete data from headers
       run: |
+        source root/bin/thisroot.sh
         python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend pyroot --no-skip-incomplete --benchmark ${{ github.sha }}
     - name: Read a sample file (all)
       run: |

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -29,22 +29,30 @@ jobs:
       uses: actions/cache@v4
       with:
         path: tests/data
-        key: data
+        key: test-data
     - name: Download sample file
       if: steps.cache-sample-file.outputs.cache-hit != 'true'
       run: |
-        wget https://rnog-data.zeuthen.desy.de/rnog_share/mattak_ci_data/station23_run325.root
-        wget https://rnog-data.zeuthen.desy.de/rnog_share/mattak_ci_data/volCalConsts_pol9_s11_1687936603-1687938078.root
-        mkdir -p tests/data/station23/run325
-        mv -v station23_run325.root tests/data/station23/run325/combined.root
-        mv -v volCalConsts_pol9_s11_1687936603-1687938078.root tests/data/station23/run325/
+        wget https://rnog-data.zeuthen.desy.de/rnog_share/mattak_ci/station23.tar.gz
+        mkdir -p tests/data
+        tar -xaf station23.tar.gz tests/data/
+    - name: Get previous benchmark results
+      uses: actions/cache/restore@v4
+      with:
+        path: tests/benchmark.json
+        key: benchmark-data
     - name: Test installation (ROOTless)
       run: |
         pip install -v .
     - name: Read a sample file (ROOTless)
       run: |
-        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend uproot
-        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend uproot --calibrate -vc tests/data/station23/run325/volCalConsts_pol9_s11_1687936603-1687938078.root
+        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend uproot --benchmark ${{ github.sha }}
+    - name: Calibrate a sample file (ROOTless)
+      run: |
+        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend uproot --calibrate -vc tests/data/station23/run325/volCalConsts_pol9_s11_1687936603-1687938078.root --benchmark ${{ github.sha }}
+    - name: Read incomplete data from headers (ROOTless)
+      run: |
+        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend uproot --no-skip-incomplete --benchmark ${{ github.sha }}
     - name: Cache ROOT
       id: cache-root
       uses: actions/cache@v4
@@ -67,8 +75,13 @@ jobs:
     - name: Read a sample file (ROOT)
       run: |
         source root/bin/thisroot.sh
-        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend pyroot
-        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend pyroot --calibrate -vc tests/data/station23/run325/volCalConsts_pol9_s11_1687936603-1687938078.root
+        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend pyroot --benchmark ${{ github.sha }}
+    - name: Calibrate a sample file
+      run: |
+        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend pyroot --calibrate -vc tests/data/station23/run325/volCalConsts_pol9_s11_1687936603-1687938078.root --benchmark ${{ github.sha }}
+    - name: Read incomplete data from headers
+      run: |
+        python3 tests/test_dataset.py --station=0 --run=0 --data_dir=./tests/data/station23/run325 --backend pyroot --no-skip-incomplete --benchmark ${{ github.sha }}
     - name: Read a sample file (all)
       run: |
         source root/bin/thisroot.sh
@@ -79,3 +92,12 @@ jobs:
         source root/bin/thisroot.sh
         python3 tests/compare_backends.py --station=0 --run=0 --data_dir tests/data/station23/run325/ -vc tests/data/station23/run325//volCalConsts_pol9_s11_1687936603-1687938078.root
         python3 tests/compare_backends.py --station=0 --run=0 --data_dir tests/data/station23/run325/ -vc tests/data/station23/run325//volCalConsts_pol9_s11_1687936603-1687938078.root --calibrate
+    - name: Benchmark against previous results
+      run: |
+        python3 tests/evaluate_benchmarks.py --benchmark-file tests/benchmark.json ${{ github.sha }}
+    - name: Export benchmark results (only on main)
+      if: ${{ github.ref == 'refs/heads/main'}}
+      uses: actions/cache/save@v4
+      with:
+        key: benchmark-data
+        path: tests/benchmark.json

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -185,7 +185,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             sampleRate=sampleRate,
             radiantThrs=radiantThrs,
             lowTrigThrs=lowTrigThrs,
-            hasWaveforms=not isNully(self.ds.wfTree()),
+            hasWaveforms= self.ds.rawAvailable()
             readoutDelay=readout_delay)
 
 

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -185,7 +185,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             sampleRate=sampleRate,
             radiantThrs=radiantThrs,
             lowTrigThrs=lowTrigThrs,
-            hasWaveforms= self.ds.rawAvailable()
+            hasWaveforms= self.ds.rawAvailable(),
             readoutDelay=readout_delay)
 
 

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -140,14 +140,8 @@ class Dataset(mattak.Dataset.AbstractDataset):
             radiantThrs = numpy.array(daq_status.radiant_thresholds)
             lowTrigThrs = numpy.array(daq_status.lt_trigger_thresholds)
 
-        # the default value for the sampling rate (3.2 GHz) which is used
-        # for data which does not contain this information in the waveform files
-        # is set in the header fils Waveforms.h
-        try:
-            sampleRate = self.ds.raw().radiant_sampling_rate / 1000
-        except ReferenceError:
-            # Fall back to runinfo (as in uproot backend)
-            sampleRate = self.ds.info().radiant_sample_rate / 1000
+        # now use Dataset's faster sample rate getter
+        sampleRate = self.ds.radiantSampleRate() / 1000
 
         hdr = self.ds.header()
 
@@ -174,7 +168,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             dtype='uint8', count=self.NUM_CHANNELS * 2).reshape(self.NUM_CHANNELS, 2))
 
         readout_delay = numpy.copy(numpy.around(numpy.frombuffer(
-            cppyy.ll.cast['float*'](self.ds.raw().digitizer_readout_delay_ns),
+            cppyy.ll.reinterpret_cast['float*'](self.ds.radiantReadoutDelays()),
             dtype = numpy.float32, count=self.NUM_CHANNELS)))
 
         return mattak.Dataset.EventInfo(
@@ -191,7 +185,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             sampleRate=sampleRate,
             radiantThrs=radiantThrs,
             lowTrigThrs=lowTrigThrs,
-            hasWaveforms=not isNully(self.ds.raw()),
+            hasWaveforms=not isNully(self.ds.wfTree()),
             readoutDelay=readout_delay)
 
 

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -321,23 +321,23 @@ class Dataset(mattak.Dataset.AbstractDataset):
 
         infos = []
         info = None  # if range(0)
-        for i, triggerInfoi in zip(range(self.last - self.first), triggerInfo):
+        for i, t_info in zip(range(self.last - self.first), triggerInfo):
 
             if override_skip_incomplete is not None and override_skip_incomplete:
                 if eventNumber[i] not in self.events_with_waveforms.keys():
                     continue
 
             triggerType  = "UNKNOWN"
-            if triggerInfoi['trigger_info.radiant_trigger']:
-                which = triggerInfoi['trigger_info.which_radiant_trigger']
+            if t_info['trigger_info.radiant_trigger']:
+                which = t_info['trigger_info.which_radiant_trigger']
                 if which == -1:
                     which = "X"
                 triggerType = "RADIANT" + str(which)
-            elif triggerInfoi['trigger_info.lt_trigger']:
+            elif t_info['trigger_info.lt_trigger']:
                 triggerType = "LT"
-            elif triggerInfoi['trigger_info.force_trigger']:
+            elif t_info['trigger_info.force_trigger']:
                 triggerType = "FORCE"
-            elif triggerInfoi['trigger_info.pps_trigger']:
+            elif t_info['trigger_info.pps_trigger']:
                 triggerType = "PPS"
 
             radiantThrs = None

--- a/src/mattak/Dataset.h
+++ b/src/mattak/Dataset.h
@@ -71,6 +71,7 @@ namespace mattak
       int loadDir(const char * dir);
       int loadCombinedFile(const char * file);
 
+      int currentEntry() const { return current_entry; }
 
       /**
        * Deprecated, kept for ABI compatibility
@@ -87,6 +88,13 @@ namespace mattak
 
       mattak::Header * header(bool force_reload = false);
       mattak::Waveforms * raw(bool force_reload = false);
+
+      // these methods are useful if you want to read waveform metadata without reading the waveforms
+      // if you are reading the waveforms, they are less efficient than getting what you want from raw
+      float radiantSampleRate(bool force_reload = false);
+      const float * radiantReadoutDelays(bool force_reload = false);  //size is mattak::k::num_radiant_channels, returning a float* since cppyyy doesn't seem to be able to deal with std::array properly
+      
+      
       mattak::CalibratedWaveforms * calibrated(bool force_reload = false); //will be nullptr if no calibration is passed
       mattak::DAQStatus * status(bool force_reload = false);
       mattak::RunInfo * info() const { return runinfo.ptr; }
@@ -129,17 +137,21 @@ namespace mattak
       static const char ** getDAQStatusTreeNames();
       static const char ** getPedestalTreeNames();
     private:
-
-
       tree_field<Waveforms> wf;
       tree_field<Header> hd;
       tree_field<DAQStatus> ds;
       tree_field<Pedestals> pd;
       file_field<RunInfo> runinfo;
+
+      tree_field<uint32_t> sample_rate;
+      tree_field<std::array<float,mattak::k::num_radiant_channels>> delays;
+      void setupRadiantMeta();
+
       field<CalibratedWaveforms> calib_wf;
 
       void unload();
       int current_entry = 0;
+
 
       bool full_dataset ;
       DatasetOptions opt;

--- a/src/mattak/Dataset.h
+++ b/src/mattak/Dataset.h
@@ -89,6 +89,14 @@ namespace mattak
       mattak::Header * header(bool force_reload = false);
       mattak::Waveforms * raw(bool force_reload = false);
 
+      // is the raw data available for currentEntry? (mostly used by PyROOT backend) 
+      bool rawAvailable(bool force_reload = false) 
+      {  
+        return  wf.tree && 
+         ( full_dataset || opt.partial_skip_incomplete || 
+           wf.tree->GetEntryNumberWithIndex(header(force_reload)->event_number) >=0); 
+      }
+
       // these methods are useful if you want to read waveform metadata without reading the waveforms
       // if you are reading the waveforms, they are less efficient than getting what you want from raw
       float radiantSampleRate(bool force_reload = false);

--- a/tests/evaluate_benchmarks.py
+++ b/tests/evaluate_benchmarks.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+import numpy as np
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--benchmark-file', default='benchmark.json', help='Path to json file with benchmark data')
+argparser.add_argument('--threshold', type=float, default=1.5, help='Maximum increase over median previous benchmark; will raise an error if exceeded.')
+argparser.add_argument('tag', type=str, help='Tag of benchmark to test against other benchmarks')
+
+args = argparser.parse_args()
+
+with open(args.benchmark_file, 'r') as f:
+    benchmarks = json.load(f)
+
+test_benchmark = benchmarks.pop(args.tag)
+exit_code = 0
+for key, test_value in test_benchmark.items():
+    old_values = []
+    for run_tag, run in benchmarks.items():
+        if key in run:
+            old_values.append(run[key])
+
+    if not len(old_values):
+        print(f'Skipping key: {key} with no previous benchmark data.')
+        continue
+
+    reference = np.median(old_values)
+    print(f'{key:20s} : {test_value*1e3:-7.3f} ms / {reference*1e3:-7.3f} ({test_value/reference*100:-4.0f} %)')
+    exit_code += test_value/reference > args.threshold
+
+if exit_code:
+    print(f"!!! {exit_code} benchmark tests have failed !!!")
+
+exit(exit_code)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -55,8 +55,6 @@ if __name__ == "__main__":
             import json
             benchmark_file = os.path.join(os.path.dirname(__file__), 'benchmark.json')
             if not os.path.exists(benchmark_file):
-                with open(benchmark_file, 'w') as f:
-                    pass
                 benchmarks = {}
             else:
                 with open(benchmark_file, 'r') as f:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -11,31 +11,64 @@ if __name__ == "__main__":
     argparser.add_argument('--voltage_calibration', '-vc', type=str, default=None)
     argparser.add_argument('--calibrate', action="store_true")
     argparser.add_argument('--backend', nargs='*', help="Which backend(s) to test", default=['pyroot', 'uproot'])
+    argparser.add_argument(
+        '--no-skip-incomplete', action='store_true',
+        help='If True, test the `skip_incomplete=False` option which tries to read (header)data also for events for which no waveforms are present.' )
+    argparser.add_argument('--benchmark', type=str, default=None, help="If provided, store benchmark results in this file.")
     args = argparser.parse_args()
 
     calibrated = args.calibrate
+    skip_incomplete = not args.no_skip_incomplete
+    print(f"Test settings: voltage_calibration: {calibrated} / skip_incomplete: {skip_incomplete}")
 
     for backend in args.backend:
         print(f">----- Testing backend: {backend} -----<")
         d = mattak.Dataset.Dataset(
             args.station, args.run, data_path=args.data_dir,
             backend=backend, verbose=True,
-            voltage_calibration=args.voltage_calibration)
+            voltage_calibration=args.voltage_calibration,
+            skip_incomplete=skip_incomplete)
 
         print(d.N())
         print(d.eventInfo())
-        print(d.wfs(calibrated=calibrated))
+        if skip_incomplete:
+            print(d.wfs(calibrated=calibrated))
 
         d.setEntries((1, 2))
         print(d.eventInfo())
-        print(d.wfs(calibrated=calibrated))
+        if skip_incomplete:
+            print(d.wfs(calibrated=calibrated))
 
         mean = 0
         start = time.time()
         for idx, ev in enumerate(d.iterate(calibrated=calibrated)):
-            mean += numpy.average(ev[1])
+            if skip_incomplete:
+                mean += numpy.average(ev[1])
 
         end = time.time()
+        time_per_event = (end - start) / (idx + 1)
         print(mean / d.N())
         print("Total time:", end - start)
-        print("Time per event:", (end - start) / (idx + 1))
+        print("Time per event:", time_per_event)
+        if args.benchmark is not None:
+            import os
+            import json
+            benchmark_file = os.path.join(os.path.dirname(__file__), 'benchmark.json')
+            if not os.path.exists(benchmark_file):
+                with open(benchmark_file, 'w') as f:
+                    pass
+                benchmarks = {}
+            else:
+                with open(benchmark_file, 'r') as f:
+                    benchmarks = json.load(f)
+
+            tag = args.benchmark
+            # store benchmark results separately per backend / calibration setting / skip_incomplete
+            subtag = f'{backend}' + ['', '/cal'][calibrated] + ['/inc', ''][skip_incomplete]
+            if not tag in benchmarks:
+                benchmarks[tag] = {}
+            benchmarks[tag][subtag] = time_per_event
+
+            with open(benchmark_file, 'w') as f:
+                json.dump(benchmarks, f, indent=4)
+


### PR DESCRIPTION
Based on #89 

Adds tests for `skip_incomplete=True` and also a first effort at a benchmark test - all workflow runs on `main` should store the time per event required for each configuration of backend/calibration etc, and the test will fail if a new branch increases the time on any of these by more than 50%.

It's not the tidiest code I've ever written and we can probably do something smarter but maybe this is good enough for now.

(As an aside - a consequence of benchmark data only being stored on `main` means that it doesn't actually compare anything yet, so we'll have to see if it works or not in due course :)