### PR TITLE
uproot backend - fix double occurrence of library argument in array

### DIFF
--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -312,7 +312,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
             sampleRate = [sampleRate] * (self.last - self.first)
 
         try:
-            readout_delay = self._wfs[f"mattak::IWaveforms/digitizer_readout_delay_ns[{self.NUM_CHANNELS}]"].array(library='np', **kw)
+            readout_delay = self._wfs[f"mattak::IWaveforms/digitizer_readout_delay_ns[{self.NUM_CHANNELS}]"].array(**kw)
         except uproot.exceptions.KeyInFileError:
             readout_delay = numpy.zeros((self.last - self.first, self.NUM_CHANNELS))
 


### PR DESCRIPTION
In the uproot backend, the `library` argument was entered twice in an uproot array (once explicitly and once through `**kw`). This leads to the following error: `TypeError: uproot.behaviors.TBranch.TBranch.array() got multiple values for keyword argument 'library'`.

The problem is resolved in this PR by deleting the explicit argument.