### PR TITLE
Hotfix/fix pyproject homepage specification

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -3,6 +3,8 @@ name: Test install
 on:
   push:
   workflow_dispatch:
+  schedule: # run once a week on Sunday to prevent benchmark file from being evicted - there may be a better solution
+    - cron: '0 0 * * SUN'
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ PIP_INSTALLATION = true
 name = "mattak"
 version = "0.1.9"
 authors = [{name="Cosmin Deaconu, email=<cozzyd@kicp.uchicago.edu>"}]
-homepage = "https://github.com/RNO-G/mattak"
 readme = "README.md"
 description = "Mattak is (will eventually be) a multilingual package containing readers and helpers for RNO-G in C++, Python (via both uproot and PyROOT) and maybe even JS (via rootjs)."
 dependencies = ["numpy", "uproot", "awkward", "libconf"]
+
+[project.urls]
+homepage = "https://github.com/RNO-G/mattak"

--- a/tests/evaluate_benchmarks.py
+++ b/tests/evaluate_benchmarks.py
@@ -31,5 +31,4 @@ for key, test_value in test_benchmark.items():
 
 if exit_code:
     print(f"!!! {exit_code} benchmark tests have failed !!!")
-
-sys.exit(exit_code)
+    sys.exit(exit_code)


### PR DESCRIPTION
The NuRadio tests have started failing because the `homepage` in the mattak pyproject.toml wasn't specified correctly. Not sure who's started to pay attention but this fixes it.

I've also hopefully fixed the benchmark test by only calling `sys.exit` if the benchmark actually fails - my best guess is that bash was interpreting `exit(0)` as an error. Furthermore, I realized that storing the benchmark file using github cache is not ideal, because the cache gets evicted after 7 days if it's not used. For now I've made this an exciting race by also scheduling an automatic workflow run on the main branch every 7 days. Possibly the better solution is to use artifacts instead, but I think this should be okay for now as the entire workflow only takes a couple of minutes anyway. (This should also help us catch stuff breaking when dependencies get updated, for example, so it's not a complete waste of compute).