### PR TITLE
Look for calibration files

### DIFF
--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -342,9 +342,9 @@ def Dataset(station : int = 0, run : int = 0, data_path : Optional[str] = None, 
         return None
 
 
-def find_voltage_calibration_for_dataset(dataset):
+def find_voltage_calibration_for_dataset(dataset, i=0):
     """ Wrapper around find_voltage_calibration """
-    dataset.setEntries(0)
+    dataset.setEntries(i)
     return find_voltage_calibration(dataset.rundir, dataset.station, dataset.eventInfo().triggerTime)
 
 
@@ -355,6 +355,7 @@ def find_voltage_calibration(rundir, station, time, log_error=False):
     The order of the search is:
         * run directory
         * under RNO_G_DATA/calibration/stationX
+        * under RNO_G_CAL/stationX        
 
     Parameters
     ----------
@@ -385,10 +386,18 @@ def find_voltage_calibration(rundir, station, time, log_error=False):
                 vc_dir = f"{os.environ[env_var]}/calibration/station{station}"
                 vc_list = glob.glob(f"{vc_dir}/volCalConst*.root")
                 break
+        
+        if not vc_list:
+            env_var = "RNO_G_CAL"
+            if env_var in os.environ:
+                vc_dir = f"{os.environ[env_var]}/station{station}"
+                vc_list = glob.glob(f"{vc_dir}/**/volCalConst*.root", recursive=True)
 
         if vc_dir is None:
             msg = ("Could not find a directory for the calibration files. "
-                "Was `RNO_G_DATA` or `RNO_G_ROOT_DATA` defined as a system env variable?")
+                "Was `RNO_G_DATA` or `RNO_G_ROOT_DATA` defined as a system env variable?"
+                "You can also set the RNO_G_CAL env variable to point to the calibration directory"
+                )
             if log_error:
                 logging.error(msg)
             else:

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -389,6 +389,17 @@ class Dataset(mattak.Dataset.AbstractDataset):
         """ Helper to access uproot file """
         return self._wfs[f'radiant_data[{self.NUM_CHANNELS}][{self.NUM_WF_SAMPLES}]'].array(**kw)
 
+    def set_calibration(self, voltage_calibration : str, cache_calibration : Optional[bool] = True):
+        """
+        Function to manually set a voltage calibration after the dataset is initialised
+        """
+        if hasattr(self, 'vc'):
+            del self.vc
+        if isinstance(voltage_calibration, str):
+            self.vc = VoltageCalibration(voltage_calibration, caching=cache_calibration)
+        else:
+            Raise(ValueError("This function only accepts path to voltage calibration"))
+
     def wfs(self, calibrated : bool = False, channels : Optional[Union[int, List[int]]] = None, override_skip_incomplete : Optional[bool] = None) -> Optional[numpy.ndarray]:
         """
         Returns the waveform data for the selected event(s).


### PR DESCRIPTION
This pull request adds the option to define a RNO_G_CAL environmental variable that points to the directory that contains the calibration files. The searcher still lists all volCal files and picks the one that is closest to time to the desired data run. In the future this can be changed to be more efficient be using the run numbers. (e.g. only looking for the closes run number containing a volCal file)