### PR TITLE
Lzma fix

### DIFF
--- a/prog/rno-g-combine.cc
+++ b/prog/rno-g-combine.cc
@@ -17,6 +17,7 @@
 #include "TRandom.h" 
 #include "TEventList.h"
 #include "TRandom3.h" 
+#include "Compression.h"
 
 
 

--- a/prog/rno-g-combine.cc
+++ b/prog/rno-g-combine.cc
@@ -16,9 +16,7 @@
 #include "TTree.h" 
 #include "TRandom.h" 
 #include "TEventList.h"
-#include "TRandom3.h" 
-#include "Compression.h"
-
+#include "TRandom3.h"
 
 
 int main (int nargs, char ** args) 
@@ -71,7 +69,7 @@ int main (int nargs, char ** args)
 
 
 
-  TFile of(args[1],"RECREATE","CombinedFile",ROOT::CompressionSettings(ROOT::kLZMA,5)); 
+  TFile of(args[1],"RECREATE","CombinedFile",ROOT::CompressionSettings(ROOT::RCompressionSetting::EAlgorithm::kLZMA,5)); 
   mattak::Waveforms * wf = 0;
   mattak::Header * hd = 0;
   mattak::DAQStatus * ds = 0;


### PR DESCRIPTION
In ROOT 6.36 they deprecated the `ROOT::kLZMA` enum. https://github.com/root-project/root/commit/439a26c914e3d8f26bb7864fb38b103a99d45a05

Now it's `ROOT::RCompressionSetting::EAlgorithm::kLZMA` only.