### PR TITLE
fixed KeyInFileError caused by the change in trigger threshold keys with uproot backend

### DIFF
--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -293,7 +293,6 @@ class Dataset(mattak.Dataset.AbstractDataset):
             try:
                 self._lowTrigThrs = numpy.array(self._dss['lt_trigger_thresholds[4]'])
             except uproot.exceptions.KeyInFileError:
-                self._lowTrigThrs = None
                 self._lowTrigThrs = numpy.array(self._dss['lt_coinc_trigger_thresholds[4]'])
             self._readout_time_radiant = numpy.array(self._dss['readout_time_radiant'])
             self._readout_time_lt = numpy.array(self._dss['readout_time_lt'])


### PR DESCRIPTION
fixed KeyInFileError caused by the change from 'lt_trigger_threshold[4]' to 'lt_coinc_trigger_thresholds[4]'. We are not sure about the new lt_phased_trigger_thresholds[12].