### PR TITLE
Fix bug in dataset.iterate (pyroot backend)

### DIFF
--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -219,19 +219,55 @@ class AbstractDataset(ABC):
     @abstractmethod
     def _iterate(self, start: int , stop : int , calibrated: bool, max_entries_in_mem: int,
                  selectors: Optional[Union[Callable[[EventInfo], bool],
-                                           Sequence[Callable[[EventInfo], bool]]]]) \
+                                           Sequence[Callable[[EventInfo], bool]]]],
+                 copy : bool = True) \
                  -> Generator[Tuple[Optional[EventInfo], Optional[numpy.ndarray]], None, None]:
-        """ implementation-defined part of iterator"""
+        """ Implementation-defined part of the iterator. See `iterate` for the meaning of the arguments. """
         pass
 
     def iterate(
             self, start : int = 0, stop : Union[int, None] = None,
             calibrated: bool = False, max_entries_in_mem : int = 256,
             selectors: Optional[Union[Callable[[EventInfo], bool], Sequence[Callable[[EventInfo], bool]]]] = None,
-            override_skip_incomplete : Optional[bool] = None) \
+            override_skip_incomplete : Optional[bool] = None,
+            copy : bool = True) \
                 -> Generator[Tuple[Optional[EventInfo], Optional[numpy.ndarray]], None, None]:
-        """ Iterate over events from start to stop, holding at most max_entries_in_mem in RAM.
-            Returns a tuple of EventInfo and the event waveforms (potentially calibrated).
+        """
+        Iterate over events from start to stop, holding at most max_entries_in_mem in RAM.
+        Yields tuples of EventInfo and the event waveforms (potentially calibrated).
+
+        Parameters
+        ----------
+        start : int (Default: 0)
+            Index of the first event to iterate over. Negative indices count from the end.
+
+        stop : int or None (Default: None)
+            Index of the first event *not* to iterate over (i.e., exclusive). If None,
+            iterate until the end of the dataset. Negative indices count from the end.
+
+        calibrated : bool (Default: False)
+            If True, yield voltage-calibrated waveforms (requires a voltage calibration).
+            Otherwise yield the raw ADC counts.
+
+        max_entries_in_mem : int (Default: 256)
+            Maximum number of events which are loaded into memory at once
+            (only relevant for the uproot backend which reads events in batches).
+
+        selectors : callable or list of callables (Default: None)
+            One or more functions which take an EventInfo and return a bool. Only events
+            for which all selectors return True are yielded.
+
+        override_skip_incomplete : bool (Default: None)
+            If not None, override the `skip_incomplete` setting of the dataset
+            (see `mattak.Dataset.Dataset`) for this iteration.
+
+        copy : bool (Default: True)
+            **PyROOT backend exclusive!** If True, yield a copy of each waveform array
+            (cast to float). If False, yield an array which references the backend's
+            internal memory: it is only valid until the next event is read, i.e., its
+            content will change while iterating. Only set this to False if you process
+            each waveform immediately and care about the (small) performance gain.
+            The uproot backend ignores this argument, it always yields independent arrays.
         """
         if start < 0:
             start += self.N()
@@ -248,7 +284,8 @@ class AbstractDataset(ABC):
         if stop < 0 or start > self.N():
             return
 
-        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, selectors, override_skip_incomplete=override_skip_incomplete)
+        yield from self._iterate(start, stop, calibrated, max_entries_in_mem, selectors,
+                                 override_skip_incomplete=override_skip_incomplete, copy=copy)
 
     @abstractmethod
     def eventInfo(self) -> Union[Optional[EventInfo], Sequence[Optional[EventInfo]]]:

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -257,9 +257,27 @@ class Dataset(mattak.Dataset.AbstractDataset):
     def _iterate(
             self, start : int, stop : int, calibrated : bool , max_in_mem : int,
             selectors: Optional[Union[Callable[[mattak.Dataset.EventInfo], bool], Sequence[Callable[[mattak.Dataset.EventInfo], bool]]]] = None,
-            override_skip_incomplete : Optional[bool] = None) -> Generator[Tuple[Optional[mattak.Dataset.EventInfo], Optional[numpy.ndarray]], None, None]:
+            override_skip_incomplete : Optional[bool] = None,
+            copy : bool = True) -> Generator[Tuple[Optional[mattak.Dataset.EventInfo], Optional[numpy.ndarray]], None, None]:
+        """
+        PyROOT implementation of the iterator. See `mattak.Dataset.AbstractDataset.iterate`
+        for the meaning of the arguments.
+
+        If `copy` is True (default), each yielded waveform array is a copy (cast to float).
+        If False, the yielded array references the memory of the underlying ROOT object,
+        which is overwritten when the next event is read: the yielded array is only valid
+        until the next iteration step (and keeps the raw dtype, i.e., int16 for uncalibrated
+        waveforms).
+        """
 
         skip_incomplete = override_skip_incomplete or self.ds.getOpt().partial_skip_incomplete
+
+        def copy_wfs(wfs):
+            # numpy.array (unlike numpy.asarray) guarantees a copy also when
+            # the dtype already matches (i.e., for calibrated waveforms)
+            if wfs is None or not copy:
+                return wfs
+            return numpy.array(wfs, dtype=float)
 
         if selectors is not None:
             if not isinstance(selectors, (list, numpy.ndarray)):
@@ -271,10 +289,10 @@ class Dataset(mattak.Dataset.AbstractDataset):
                 if skip_incomplete and wfs is None:
                     continue
                 if evinfo is not None and numpy.all([selector(evinfo) for selector in selectors]):
-                    yield evinfo, numpy.asarray(wfs, dtype=float)
+                    yield evinfo, copy_wfs(wfs)
         else:
             for i in range(start, stop):
                 wfs = self._wfs(i, calibrated)
                 if skip_incomplete and wfs is None:
                     continue
-                yield self._eventInfo(i), numpy.asarray(wfs, dtype=float)
+                yield self._eventInfo(i), copy_wfs(wfs)

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -271,10 +271,10 @@ class Dataset(mattak.Dataset.AbstractDataset):
                 if skip_incomplete and wfs is None:
                     continue
                 if evinfo is not None and numpy.all([selector(evinfo) for selector in selectors]):
-                    yield evinfo, wfs
+                    yield evinfo, numpy.asarray(wfs, dtype=float)
         else:
             for i in range(start, stop):
                 wfs = self._wfs(i, calibrated)
                 if skip_incomplete and wfs is None:
                     continue
-                yield self._eventInfo(i), wfs
+                yield self._eventInfo(i), numpy.asarray(wfs, dtype=float)

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -525,8 +525,16 @@ class Dataset(mattak.Dataset.AbstractDataset):
             self, start : int, stop : int, calibrated: bool,  max_in_mem : int,
             selectors: Optional[Union[Callable[[mattak.Dataset.EventInfo], bool],
             Sequence[Callable[[mattak.Dataset.EventInfo], bool]]]] = None,
-            override_skip_incomplete : Optional[bool] = None) \
+            override_skip_incomplete : Optional[bool] = None,
+            copy : bool = True) \
             -> Generator[Tuple[Optional[mattak.Dataset.EventInfo], Optional[numpy.ndarray]], None, None]:
+        """
+        Uproot implementation of the iterator. See `mattak.Dataset.AbstractDataset.iterate`
+        for the meaning of the arguments.
+
+        The `copy` argument is ignored (it is exclusive to the pyroot backend): this backend
+        always yields independent arrays which do not reference any internal memory.
+        """
 
         # cache current values given by setEntries(..)
         original_entry = self.getEntries()

--- a/tests/compare_backends.py
+++ b/tests/compare_backends.py
@@ -62,4 +62,18 @@ if __name__ == "__main__":
     for ev_py, ev_up in zip(eventInfos_pyroot, eventInfos_uproot):
         assert compare_event_info(ev_py, ev_up), "Backends return different event infos"
 
+
+    dset_pyroot.setEntries((0, 5))
+    dset_uproot.setEntries((0, 5))
+
+    wfs_py = []
+    wfs_up = []
+    for (_, wf_py), (_, wf_up) in zip(dset_pyroot.iterate(), dset_uproot.iterate()):
+        assert numpy.all(wf_py == wf_up), "Backends return different waveforms during iterate"
+        wfs_py.append(wf_py)
+        wfs_up.append(wf_up)
+
+    assert numpy.allclose(wfs_py, wfs_up), "Backends return different waveforms after iterate"
+    assert not numpy.allclose(wfs_py[0], wfs_py[1]), "Waveforms returned by pyroot backend are identical"
+
     print("Successful")

--- a/tests/compare_backends.py
+++ b/tests/compare_backends.py
@@ -76,4 +76,20 @@ if __name__ == "__main__":
     assert numpy.allclose(wfs_py, wfs_up), "Backends return different waveforms after iterate"
     assert not numpy.allclose(wfs_py[0], wfs_py[1]), "Waveforms returned by pyroot backend are identical"
 
+    # test the `copy` argument of iterate: with copy=False the pyroot backend yields references
+    # into ROOT's internal memory which are overwritten with each new event ...
+    wfs_py_ref = [wf for _, wf in dset_pyroot.iterate(copy=False)]
+    assert numpy.all(wfs_py_ref[0] == wfs_py_ref[1]), \
+        "With copy=False the pyroot backend should yield references (identical after iteration)"
+
+    # ... but are correct when consumed immediately
+    for (_, wf_ref), wf_copy in zip(dset_pyroot.iterate(copy=False), wfs_py):
+        assert numpy.all(wf_ref == wf_copy), \
+            "Waveforms from copy=False (consumed immediately) differ from copy=True"
+
+    # the uproot backend ignores copy=False and always yields independent arrays
+    wfs_up_ref = [wf for _, wf in dset_uproot.iterate(copy=False)]
+    assert not numpy.allclose(wfs_up_ref[0], wfs_up_ref[1]), \
+        "Waveforms returned by uproot backend are identical"
+
     print("Successful")


### PR DESCRIPTION
This PR fixes a bug where aggregating waveforms via `dataset.iterate` with the pyroot backend returned identical event waveforms (that of the last event in the for-loop. See #128. 

This fixes the issue in the 'iterate' implementation of the pyroot backend and extends the unit tests to catch those bugs in the future.