### PR TITLE
Modify data format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if (NOT DEFINED ROOTLESS)
 
     option(LIBRNO_G_SUPPORT "Support for reading / converting from raw files." OFF)
 
-    set(LIBRNO_G_PATH  "../librno-g" CACHE STRING "Additional path to search for librno-g (only necessary if not in RNO_G_INSTALL_DIR/lib)")
+    set(LIBRNO_G_PATH  "${RNO_G_INSTALL_DIR}" CACHE STRING "Additional path to search for librno-g (only necessary if not in RNO_G_INSTALL_DIR/lib)")
 
     set(H_FILES
       mattak/Header.h
@@ -121,9 +121,9 @@ if (NOT DEFINED ROOTLESS)
     if (LIBRNO_G_SUPPORT)
       add_definitions(-DLIBRNO_G_SUPPORT)
       message(STATUS "librno-g path set to: ${LIBRNO_G_PATH}")
-      message(STATUS "Searching for librno-g.so in ${LIBRNO_G_PATH}/install/lib/")
+      message(STATUS "Searching for librno-g.so in ${LIBRNO_G_PATH}/lib/")
 
-      find_library(RNO_G_LIB rno-g HINTS ${LIBRNO_G_PATH}/install/lib/ ${LIBRNO_G_PATH}/build)
+      find_library(RNO_G_LIB rno-g HINTS ${LIBRNO_G_PATH}/lib/)
 
       message(STATUS "Found librno-g: ${RNO_G_LIB}")
 

--- a/prog/rno-g-convert.cc
+++ b/prog/rno-g-convert.cc
@@ -33,7 +33,6 @@ int isdir(const char * f)
 }
 
 
-
 int main (int nargs, char ** args)
 {
 
@@ -46,7 +45,6 @@ int main (int nargs, char ** args)
     std::cerr << "Outfile should end with .root" << std::endl;
     return 1;
   }
-
 
   const char * firstinput = args[3];
   int first_input_dir = isdir(firstinput);

--- a/prog/rno-g-convert.cc
+++ b/prog/rno-g-convert.cc
@@ -1,117 +1,137 @@
-#include <iostream> 
-#include "mattak/Waveforms.h" 
-#include "mattak/Header.h" 
-#include "mattak/Pedestals.h" 
-#include "mattak/DAQStatus.h" 
-#include "mattak/Converter.h" 
+#include <iostream>
+#include <cstring>
+#include "mattak/Waveforms.h"
+#include "mattak/Header.h"
+#include "mattak/Pedestals.h"
+#include "mattak/DAQStatus.h"
+#include "mattak/Converter.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-void usage() 
+void usage()
 {
-  std::cout << "Usage: rno-g-converter TYPE OUTFILE INFILE1 [INFILE2 ...]" << std::endl; 
-  std::cout << "   or rno-g-converter TYPE OUTFILE INDIR << std::endl" << std::endl; 
-  std::cout << "   or rno-g-converter runinfo OUTFILE  auxdir [stationoverride] [runoverride] << std::endl" << std::endl; 
-  std::cout << "   TYPE can be waveforms wfs header hd daqstatus ds pedestal ped runinfo" << std::endl; 
+  std::cout << "Usage: rno-g-converter [--update] TYPE OUTFILE INFILE1 [INFILE2 ...]" << std::endl;
+  std::cout << "   or rno-g-converter [--update] TYPE OUTFILE INDIR << std::endl" << std::endl;
+  std::cout << "   or rno-g-converter runinfo OUTFILE  auxdir [stationoverride] [runoverride] << std::endl" << std::endl;
+  std::cout << "   TYPE can be waveforms wfs header hd daqstatus ds pedestal ped runinfo" << std::endl;
   std::cout << "   OUTFILE is the output ROOT file " << std::endl;
-  std::cout << "   INFILE is one or more input files in order " << std::endl; 
-  std::cout << "   INDIR is an input directory, an attempt will be made to get any number from a string and sorted. " << std::endl; 
+  std::cout << "   INFILE is one or more input files in order " << std::endl;
+  std::cout << "   INDIR is an input directory, an attempt will be made to get any number from a string and sorted. " << std::endl;
+  std::cout << "   --update extends an existing OUTFILE with the inputs it does not hold yet," << std::endl;
+  std::cout << "            instead of converting everything again. Inputs already converted" << std::endl;
+  std::cout << "            are skipped; anything unexpected falls back to a full conversion." << std::endl;
 
-  exit(1); 
+  exit(1);
 
-} 
+}
 
-int isdir(const char * f) 
+int isdir(const char * f)
 {
-  struct stat st; 
-  if (stat(f,   &st) != 0) 
+  struct stat st;
+  if (stat(f,   &st) != 0)
   {
-    return 0; 
+    return 0;
   }
-  return S_ISDIR(st.st_mode); 
+  return S_ISDIR(st.st_mode);
 }
 
 
 
-int main (int nargs, char ** args) 
+int main (int nargs, char ** args)
 {
+  bool update = false;
+  int argi = 1;
 
-  if (nargs < 4) usage(); 
-  const char * type       = args[1]; 
-  const char * outfile    = args[2]; 
-  //check if outfile ends with .root 
-  if (!TString(outfile).EndsWith(".root"))
+  while (argi < nargs && args[argi][0] == '-')
   {
-    std::cerr << "Outfile should end with .root" << std::endl; 
-    return 1; 
+    if (!strcmp(args[argi], "--update") || !strcmp(args[argi], "-u"))
+    {
+      update = true;
+      argi++;
+    }
+    else
+    {
+      if (strcmp(args[argi], "--help") && strcmp(args[argi], "-h"))
+      {
+        std::cerr << "Unknown option: " << args[argi] << std::endl;
+      }
+      usage();
+    }
   }
 
-  
-  const char * firstinput = args[3]; 
-  int first_input_dir = isdir(firstinput); 
+  if (nargs - argi < 3) usage();
+
+  const char * type       = args[argi++];
+  const char * outfile    = args[argi++];
+  //check if outfile ends with .root
+  if (!TString(outfile).EndsWith(".root"))
+  {
+    std::cerr << "Outfile should end with .root" << std::endl;
+    return 1;
+  }
+
+
+  const char * firstinput = args[argi];
+  int first_input_dir = isdir(firstinput);
+  int nfiles = nargs - argi;
   int N = 0;
 
   if (!strcmp(type,"wf") || !strcmp(type,"waveforms"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertWaveformDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertWaveformDir(firstinput, outfile,0,0,update);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertWaveformFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertWaveformFiles(nfiles, (const char**) (args+argi), outfile, 0, -1, update);
     }
   }
   else if (!strcmp(type,"hd") || !strcmp(type,"header"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertHeaderDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertHeaderDir(firstinput, outfile,0,0,update);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertHeaderFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertHeaderFiles(nfiles, (const char**) (args+argi), outfile, 0, -1, update);
     }
   }
   else if (!strcmp(type,"ds") || !strcmp(type,"daqstatus"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertDAQStatusDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertDAQStatusDir(firstinput, outfile,0,0,update);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertDAQStatusFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertDAQStatusFiles(nfiles, (const char**) (args+argi), outfile, 0, -1, update);
     }
   }
   else if (!strcmp(type,"ped") || !strcmp(type,"pedestal"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertPedestalDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertPedestalDir(firstinput, outfile,0,0,update);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertPedestalFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertPedestalFiles(nfiles, (const char**) (args+argi), outfile, 0, -1, update);
     }
   }
   else if (!strcmp(type,"runinfo"))
   {
-    return mattak::convert::makeRunInfo(firstinput,outfile, nargs > 4 ? atoi(args[4]) : -1, nargs > 5 ? atoi(args[5]) : -1 ); 
+    return mattak::convert::makeRunInfo(firstinput,outfile, nfiles > 1 ? atoi(args[argi+1]) : -1, nfiles > 2 ? atoi(args[argi+2]) : -1 );
   }
- 
+
   else
   {
-    std::cerr << "Unkown type: " << type << std::endl; 
-    return 1; 
+    std::cerr << "Unkown type: " << type << std::endl;
+    return 1;
   }
 
-  printf("Processed %d entries\n", N); 
-  return 0; 
+  printf("Processed %d entries\n", N);
+  return 0;
 }
-
-
-
-
-

--- a/prog/rno-g-convert.cc
+++ b/prog/rno-g-convert.cc
@@ -1,117 +1,112 @@
-#include <iostream> 
-#include "mattak/Waveforms.h" 
-#include "mattak/Header.h" 
-#include "mattak/Pedestals.h" 
-#include "mattak/DAQStatus.h" 
-#include "mattak/Converter.h" 
+#include <iostream>
+#include "mattak/Waveforms.h"
+#include "mattak/Header.h"
+#include "mattak/Pedestals.h"
+#include "mattak/DAQStatus.h"
+#include "mattak/Converter.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-void usage() 
+void usage()
 {
-  std::cout << "Usage: rno-g-converter TYPE OUTFILE INFILE1 [INFILE2 ...]" << std::endl; 
-  std::cout << "   or rno-g-converter TYPE OUTFILE INDIR << std::endl" << std::endl; 
-  std::cout << "   or rno-g-converter runinfo OUTFILE  auxdir [stationoverride] [runoverride] << std::endl" << std::endl; 
-  std::cout << "   TYPE can be waveforms wfs header hd daqstatus ds pedestal ped runinfo" << std::endl; 
+  std::cout << "Usage: rno-g-converter TYPE OUTFILE INFILE1 [INFILE2 ...]" << std::endl;
+  std::cout << "   or rno-g-converter TYPE OUTFILE INDIR << std::endl" << std::endl;
+  std::cout << "   or rno-g-converter runinfo OUTFILE  auxdir [stationoverride] [runoverride] << std::endl" << std::endl;
+  std::cout << "   TYPE can be waveforms wfs header hd daqstatus ds pedestal ped runinfo" << std::endl;
   std::cout << "   OUTFILE is the output ROOT file " << std::endl;
-  std::cout << "   INFILE is one or more input files in order " << std::endl; 
-  std::cout << "   INDIR is an input directory, an attempt will be made to get any number from a string and sorted. " << std::endl; 
+  std::cout << "   INFILE is one or more input files in order " << std::endl;
+  std::cout << "   INDIR is an input directory, an attempt will be made to get any number from a string and sorted. " << std::endl;
 
-  exit(1); 
+  exit(1);
 
-} 
+}
 
-int isdir(const char * f) 
+int isdir(const char * f)
 {
-  struct stat st; 
-  if (stat(f,   &st) != 0) 
+  struct stat st;
+  if (stat(f,   &st) != 0)
   {
-    return 0; 
+    return 0;
   }
-  return S_ISDIR(st.st_mode); 
+  return S_ISDIR(st.st_mode);
 }
 
 
 
-int main (int nargs, char ** args) 
+int main (int nargs, char ** args)
 {
 
-  if (nargs < 4) usage(); 
-  const char * type       = args[1]; 
-  const char * outfile    = args[2]; 
-  //check if outfile ends with .root 
+  if (nargs < 4) usage();
+  const char * type       = args[1];
+  const char * outfile    = args[2];
+  //check if outfile ends with .root
   if (!TString(outfile).EndsWith(".root"))
   {
-    std::cerr << "Outfile should end with .root" << std::endl; 
-    return 1; 
+    std::cerr << "Outfile should end with .root" << std::endl;
+    return 1;
   }
 
-  
-  const char * firstinput = args[3]; 
-  int first_input_dir = isdir(firstinput); 
+
+  const char * firstinput = args[3];
+  int first_input_dir = isdir(firstinput);
   int N = 0;
 
   if (!strcmp(type,"wf") || !strcmp(type,"waveforms"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertWaveformDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertWaveformDir(firstinput, outfile,0,0);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertWaveformFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertWaveformFiles(nargs-3, (const char**) (args+3), outfile);
     }
   }
   else if (!strcmp(type,"hd") || !strcmp(type,"header"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertHeaderDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertHeaderDir(firstinput, outfile,0,0);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertHeaderFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertHeaderFiles(nargs-3, (const char**) (args+3), outfile);
     }
   }
   else if (!strcmp(type,"ds") || !strcmp(type,"daqstatus"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertDAQStatusDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertDAQStatusDir(firstinput, outfile, 0, 0);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertDAQStatusFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertDAQStatusFiles(nargs-3, (const char**) (args+3), outfile);
     }
   }
   else if (!strcmp(type,"ped") || !strcmp(type,"pedestal"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertPedestalDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertPedestalDir(firstinput, outfile, 0, 0);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertPedestalFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertPedestalFiles(nargs-3, (const char**) (args+3), outfile);
     }
   }
   else if (!strcmp(type,"runinfo"))
   {
-    return mattak::convert::makeRunInfo(firstinput,outfile, nargs > 4 ? atoi(args[4]) : -1, nargs > 5 ? atoi(args[5]) : -1 ); 
+    return mattak::convert::makeRunInfo(firstinput, outfile, nargs > 4 ? atoi(args[4]) : -1, nargs > 5 ? atoi(args[5]) : -1 );
   }
- 
+
   else
   {
-    std::cerr << "Unkown type: " << type << std::endl; 
-    return 1; 
+    std::cerr << "Unkown type: " << type << std::endl;
+    return 1;
   }
 
-  printf("Processed %d entries\n", N); 
-  return 0; 
+  printf("Processed %d entries\n", N);
+  return 0;
 }
-
-
-
-
-

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -2,6 +2,7 @@
 import os
 import glob
 import re
+import enum
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Sequence, Union, Tuple, Optional, Generator, Callable, TypeVar
@@ -76,6 +77,26 @@ def set_log_level(level : int):
         ROOT.gErrorIgnoreLevel = ROOT.kError
     else:
         ROOT.gErrorIgnoreLevel = ROOT.kFatal
+
+
+class Digitizer(enum.IntEnum):
+    """ Pure python mirror of `mattak::Dataset::digitizer` (src/mattak/Dataset.h).
+
+    Values must stay in sync with the C++ enum by hand; the pyroot backend checks this at
+    import time (see `mattak.backends.pyroot.dataset`).
+    """
+    Unknown = 0
+    RADIANT = 1
+    DIDAQ = 2
+
+
+def digitizer_from_bytes_per_sample(bytes_per_sample : int) -> Digitizer:
+    """ Mirrors `mattak::Dataset::setDigitizer` (src/Dataset.cc). """
+    if bytes_per_sample == 1:
+        return Digitizer.DIDAQ
+    if bytes_per_sample in (0, 2):
+        return Digitizer.RADIANT
+    return Digitizer.Unknown
 
 
 @dataclass

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -214,8 +214,9 @@ class AbstractDataset(ABC):
     """
 
     # Define some contants
-    NUM_DIGI_SAMPLES = 4096
-    NUM_WF_SAMPLES = 2048
+    NUM_DIGI_SAMPLES = 4096  # For RADIANT
+    NUM_WF_SAMPLES = 2048  # For RADIANT
+    NUM_WF_DIDAQ_SAMPLES = 4096
     NUM_CHANNELS = 24
 
     def setEntries(self, i : Union[int, Tuple[int, int]]):

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -120,6 +120,9 @@ class EventInfo:
     readoutDelay: Optional[numpy.ndarray] = None  # Default value is 0 (set in the backends)
     didaqCoinThrs: Optional[numpy.ndarray] = None
     didaqPhasedTrigThrs: Optional[numpy.ndarray] = None
+    didaqStartOffsets: Optional[numpy.ndarray] = None  # mattak::DidaqTriggerInfo::start_offsets
+    didaqChannelMask: Optional[int] = None  # mattak::DidaqTriggerInfo::channel_mask
+    didaqBeamMask: Optional[int] = None  # mattak::DidaqTriggerInfo::beam_mask
 
 def _runinfo_seconds(value):
     """ Normalize a run-info timestamp to float seconds, or None if missing/zero.

--- a/py/mattak/Dataset.py
+++ b/py/mattak/Dataset.py
@@ -113,11 +113,13 @@ class EventInfo:
     pps: int
     radiantStartWindows: numpy.ndarray
     sampleRate: Optional[float]  # Sample rate, in GSa/s
-    radiantThrs: Optional[numpy.ndarray]
-    lowTrigThrs: Optional[numpy.ndarray]
-    lowphasedTrigThrs: Optional[numpy.ndarray]
+    radiantThrs: Optional[numpy.ndarray] = None
+    lowTrigThrs: Optional[numpy.ndarray] = None
+    lowphasedTrigThrs: Optional[numpy.ndarray] = None
     hasWaveforms: bool = True
     readoutDelay: Optional[numpy.ndarray] = None  # Default value is 0 (set in the backends)
+    didaqCoinThrs: Optional[numpy.ndarray] = None
+    didaqPhasedTrigThrs: Optional[numpy.ndarray] = None
 
 def _runinfo_seconds(value):
     """ Normalize a run-info timestamp to float seconds, or None if missing/zero.

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -217,13 +217,19 @@ class Dataset(mattak.Dataset.AbstractDataset):
         if isNully(wf):
             return None
 
-        if calibrated:
-            wfs = numpy.frombuffer(cppyy.ll.cast['double*'](wf.radiant_data), dtype="float64",
-                               count=self.NUM_CHANNELS * self.NUM_WF_SAMPLES).reshape(self.NUM_CHANNELS, self.NUM_WF_SAMPLES)
+        if wf.bytes_per_sample:
+            wfs = numpy.frombuffer(cast_uint8_t(wf.didaq_data), dtype="uint8",
+                            count=self.NUM_CHANNELS * 4096).reshape(self.NUM_CHANNELS, 4096)
+            wfs = wfs[:, :767]
         else:
-            # FS: I think a np.copy is not necessary here because we do it in wfs()
-            wfs = numpy.frombuffer(cast_int16_t(wf.radiant_data), dtype="int16",
-                               count=self.NUM_CHANNELS * self.NUM_WF_SAMPLES).reshape(self.NUM_CHANNELS, self.NUM_WF_SAMPLES)
+
+            if calibrated:
+                wfs = numpy.frombuffer(cppyy.ll.cast['double*'](wf.radiant_data), dtype="float64",
+                                count=self.NUM_CHANNELS * self.NUM_WF_SAMPLES).reshape(self.NUM_CHANNELS, self.NUM_WF_SAMPLES)
+            else:
+                # FS: I think a np.copy is not necessary here because we do it in wfs()
+                wfs = numpy.frombuffer(cast_int16_t(wf.radiant_data), dtype="int16",
+                                count=self.NUM_CHANNELS * self.NUM_WF_SAMPLES).reshape(self.NUM_CHANNELS, self.NUM_WF_SAMPLES)
         return wfs
 
 

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -170,6 +170,8 @@ def _get_trigger_type(hdr) -> str:
             triggerType = "DIDAQ_COINC0"
         elif t & _DIDAQ_COINC1:
             triggerType = "DIDAQ_COINC1"
+        else:
+            raise ValueError("Unknown DIDAQ trigger type! Please figure out what is going on. Abort!")
     elif ti.force_trigger:
         triggerType = "FORCE"
     elif ti.pps_trigger:

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -354,20 +354,21 @@ class Dataset(mattak.Dataset.AbstractDataset):
             return None
 
         if self.digitizer == mattak.Dataset.Digitizer.DIDAQ:
+            # this could be smarter
             wfs = numpy.frombuffer(cast_uint8_t(wf.didaq_data), dtype="uint8",
-                count=self.NUM_CHANNELS * wf.buffer_length).reshape(
-                    self.NUM_CHANNELS, wf.buffer_length)
+                count=self.NUM_CHANNELS * self.NUM_WF_DIDAQ_SAMPLES).reshape(
+                    self.NUM_CHANNELS, self.NUM_WF_DIDAQ_SAMPLES)[:, :wf.buffer_length]
         else:
 
             if calibrated:
                 wfs = numpy.frombuffer(cppyy.ll.cast['double*'](wf.radiant_data), dtype="float64",
-                    count=self.NUM_CHANNELS * wf.buffer_length).reshape(
-                        self.NUM_CHANNELS, wf.buffer_length)
+                    count=self.NUM_CHANNELS * self.NUM_WF_SAMPLES).reshape(
+                        self.NUM_CHANNELS, self.NUM_WF_SAMPLES)[:, :wf.buffer_length]
             else:
                 # FS: I think a np.copy is not necessary here because we do it in wfs()
                 wfs = numpy.frombuffer(cast_int16_t(wf.radiant_data), dtype="int16",
-                    count=self.NUM_CHANNELS * wf.buffer_length).reshape(
-                        self.NUM_CHANNELS, wf.buffer_length)
+                    count=self.NUM_CHANNELS * self.NUM_WF_SAMPLES).reshape(
+                        self.NUM_CHANNELS, self.NUM_WF_SAMPLES)[:, :wf.buffer_length]
         return wfs
 
 

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -32,6 +32,9 @@ cast_uint8_t  = cppyy.gbl.cast_uint8_t
 cppyy.cppdef(" int16_t* cast_int16_t(void * x) { return (int16_t*) x; }")
 cast_int16_t  = cppyy.gbl.cast_int16_t
 
+cppyy.cppdef(" uint16_t* cast_uint16_t(void * x) { return (uint16_t*) x; }")
+cast_uint16_t  = cppyy.gbl.cast_uint16_t
+
 def isNully(p):
     return p is None or ROOT.AddressOf(p) == 0 or cppyy.gbl.is_nully(p)
 
@@ -40,6 +43,48 @@ def _read(obj):
         return numpy.array(obj)
     except AttributeError:
         return None
+
+# mattak.Dataset.EventInfo threshold field name -> candidate mattak::DAQStatus (C++) attribute
+# names, tried in order (first one present on `daq_status` wins). More than one name covers
+# fields that were renamed across DAQStatus ClassDef versions (see DAQStatus.h).
+_DAQ_STATUS_THRESHOLD_FIELDS = {
+    "radiantThrs": ("radiant_thresholds",),
+    "lowTrigThrs": ("lt_trigger_thresholds", "lt_coinc_trigger_thresholds"),
+    "lowphasedTrigThrs": ("lt_phased_trigger_thresholds",),
+    "didaqCoinThrs": ("didaq_coin_thresholds",),
+    "didaqPhasedTrigThrs": ("didaq_phased_trigger_thresholds",),
+}
+
+
+def _read_daq_status_thresholds(daq_status) -> dict:
+    """
+    Read the per-channel/per-beam threshold arrays off a `mattak::DAQStatus` object.
+
+    For each entry in `_DAQ_STATUS_THRESHOLD_FIELDS`, tries each candidate C++ attribute name in
+    order and reads the first one that exists on `daq_status` (via `hasattr`/`getattr`, so this
+    stays robust across DAQStatus schema versions that renamed a field). A field with no matching
+    attribute at all is left as `None`.
+
+    Parameters
+    ----------
+    daq_status : ROOT.mattak.DAQStatus
+
+    Returns
+    -------
+    dict
+        Maps each `mattak.Dataset.EventInfo` threshold field name (e.g. "radiantThrs") to a
+        `numpy.ndarray` (or `None` if not available). Keys match `EventInfo`'s constructor
+        keywords exactly, so the result can be passed straight through as `**kwargs`.
+    """
+    values = {}
+    for field_name, candidate_attrs in _DAQ_STATUS_THRESHOLD_FIELDS.items():
+        value = None
+        for attr in candidate_attrs:
+            if hasattr(daq_status, attr):
+                value = _read(getattr(daq_status, attr))
+                break
+        values[field_name] = value
+    return values
 
 def _check_digitizer_enum_in_sync():
     """ Sanity check that `mattak.Dataset.Digitizer` (python) and `mattak::Dataset::digitizer`
@@ -53,6 +98,75 @@ def _check_digitizer_enum_in_sync():
             f"mattak.Dataset.Digitizer (python, {py_members}) is out of sync with "
             f"mattak::Dataset::digitizer (C++, {cpp_members}). Update mattak/Dataset.py to match "
             "src/mattak/Dataset.h.")
+
+
+# Bits within `hdr.trigger_info.didaq_info.type` identifying which DiDAQ RF trigger source fired.
+# Mirrors the RNO_G_TRIGGER_RF_DIDAQ_* constants of rno_g_trigger_type_t in librno-g's rno-g.h
+# (the DIDAQ bit itself is not needed here since `didaq_trigger` already confirms it's set).
+_DIDAQ_COINC0 = 1 << 2
+_DIDAQ_COINC1 = 1 << 6
+_DIDAQ_DEEP_PHASED = 1 << 3
+_DIDAQ_SURF_UP = 1 << 4
+_DIDAQ_SURF_DOWN = 1 << 5
+
+
+def _get_trigger_type(hdr) -> str:
+    """
+    Classify a header's trigger source into a short descriptive string.
+
+    Reads `hdr.trigger_info` (see `mattak::TriggerInfo` in TriggerInfo.h) and picks, in order,
+    whether the event was an RF trigger from RADIANT, the low-threshold (LT/FLOWER) board, or
+    DiDAQ, falling back to a forced or PPS trigger.
+
+    Parameters
+    ----------
+    hdr : ROOT.mattak.Header
+        The header of the event to classify.
+
+    Returns
+    -------
+    str
+        "RADIANT0"/"RADIANT1"/"RADIANTX" for a RADIANT RF trigger (X if which one is unknown),
+        "LT" for a low-threshold board RF trigger, one of "DIDAQ_COINC0"/"DIDAQ_COINC1"/
+        "DIDAQ_SURF_UP"/"DIDAQ_SURF_DOWN"/"DIDAQ_DEEP_PHASED" for a DiDAQ RF trigger (or
+        "DIDAQ_X" if `didaq_trigger` is set but none of the known source bits match), "FORCE"
+        for a software trigger, "PPS" for a PPS trigger, or "UNKNOWN" if nothing above matches.
+    """
+    ti = hdr.trigger_info
+
+    # RADIANT/LT and DiDAQ are different, mutually exclusive digitizers -- mattak::Header
+    # (Header.cc) should never set both for the same event. Catch it here rather than silently
+    # picking one, since it would indicate a bug in the header trigger-type decoding.
+    assert not (ti.didaq_trigger and (ti.radiant_trigger or ti.lt_trigger)), (
+        f"Header for event {hdr.event_number} decoded as both a DiDAQ trigger and a "
+        "RADIANT/LT trigger -- this should be impossible, check mattak::Header (Header.cc)")
+
+    triggerType = "UNKNOWN"
+    if ti.radiant_trigger:
+        which = ti.which_radiant_trigger
+        if which == -1:
+            which = "X"
+        triggerType = "RADIANT" + str(which)
+    elif ti.lt_trigger:
+        triggerType = "LT"
+    elif ti.didaq_trigger:
+        t = ti.didaq_info.type
+        if t & _DIDAQ_SURF_UP:
+            triggerType = "DIDAQ_SURF_UP"
+        elif t & _DIDAQ_SURF_DOWN:
+            triggerType = "DIDAQ_SURF_DOWN"
+        elif t & _DIDAQ_DEEP_PHASED:
+            triggerType = "DIDAQ_DEEP_PHASED"
+        elif t & _DIDAQ_COINC0:
+            triggerType = "DIDAQ_COINC0"
+        elif t & _DIDAQ_COINC1:
+            triggerType = "DIDAQ_COINC1"
+    elif ti.force_trigger:
+        triggerType = "FORCE"
+    elif ti.pps_trigger:
+        triggerType = "PPS"
+
+    return triggerType
 
 
 _check_digitizer_enum_in_sync()
@@ -162,57 +276,40 @@ class Dataset(mattak.Dataset.AbstractDataset):
         if not self.ds.setEntry(i):
             return None
 
-        radiantThrs = None
-        lowTrigThrs = None
-        lowphasedTrigThrs = None
-        didaqCoinThrs = None
-        didaqPhasedTrigThrs = None
+        daq_thresholds = {field_name: None for field_name in _DAQ_STATUS_THRESHOLD_FIELDS}
         if self.__read_daq_status:
-            daq_status = self.ds.status()
-
-            radiantThrs = _read(daq_status.radiant_thresholds)
-
-            lowTrigThrs = _read(daq_status.lt_trigger_thresholds)
-            if lowTrigThrs is None:
-                lowTrigThrs = _read(daq_status.lt_coinc_trigger_thresholds)
-
-            lowphasedTrigThrs = _read(daq_status.lt_phased_trigger_thresholds)
-
-            didaqCoinThrs = _read(daq_status.didaq_coin_thresholds)
-            didaqPhasedTrigThrs = _read(daq_status.didaq_phased_trigger_thresholds)
-
+            daq_thresholds = _read_daq_status_thresholds(self.ds.status())
 
         # now use Dataset's faster sample rate getter
-        sampleRate = self.ds.radiantSampleRate() / 1000
+        sampleRate = self.ds.sampleRate() / 1000
 
         hdr = self.ds.header()
+        triggerType = _get_trigger_type(hdr)
 
-        assert(hdr.station_number == self.station)
-        assert(hdr.run_number == self.run)
+        radiantStartWindows = None
+        readout_delay = None
+        didaqStartOffsets = None
+        didaqChannelMask = None
+        didaqBeamMask = None
 
-        triggerType = "UNKNOWN"
-        if hdr.trigger_info.radiant_trigger:
-            which = hdr.trigger_info.which_radiant_trigger
-            if which == -1:
-                which = "X"
-            triggerType = "RADIANT" + str(which)
-        elif hdr.trigger_info.lt_trigger:
-            triggerType = "LT"
-        elif hdr.trigger_info.force_trigger:
-            triggerType = "FORCE"
-        elif hdr.trigger_info.pps_trigger:
-            triggerType = "PPS"
-
-        # The `numpy.copy(...)`` is strictly necessary. Otherwise group access via `dataset.eventInfo()`
-        # results in the same `radiantStartWindows` for each event (only for the last event it is correct)
-        radiantStartWindows = numpy.copy(numpy.frombuffer(
-                cast_uint8_t(hdr.trigger_info.radiant_info.start_windows),
-                dtype='uint8', count=self.NUM_CHANNELS * 2).reshape(self.NUM_CHANNELS, 2))
+        if self.digitizer == mattak.Dataset.Digitizer.RADIANT:
+            # The `numpy.copy(...)`` is strictly necessary. Otherwise group access via `dataset.eventInfo()`
+            # results in the same `radiantStartWindows` for each event (only for the last event it is correct)
+            radiantStartWindows = numpy.copy(numpy.frombuffer(
+                    cast_uint8_t(hdr.trigger_info.radiant_info.start_windows),
+                    dtype='uint8', count=self.NUM_CHANNELS * 2).reshape(self.NUM_CHANNELS, 2))
 
 
-        readout_delay = numpy.copy(numpy.around(numpy.frombuffer(
-            cppyy.ll.reinterpret_cast['float*'](self.ds.radiantReadoutDelays()),
-            dtype = numpy.float32, count=self.NUM_CHANNELS)))
+            readout_delay = numpy.copy(numpy.around(numpy.frombuffer(
+                cppyy.ll.reinterpret_cast['float*'](self.ds.radiantReadoutDelays()),
+                dtype = numpy.float32, count=self.NUM_CHANNELS)))
+        elif self.digitizer == mattak.Dataset.Digitizer.DIDAQ:
+            didaqStartOffsets = numpy.copy(numpy.frombuffer(
+                    cast_uint16_t(hdr.trigger_info.didaq_info.start_offsets),
+                    dtype='uint16', count=self.NUM_CHANNELS))
+
+            didaqChannelMask = hdr.trigger_info.didaq_info.channel_mask
+            didaqBeamMask = hdr.trigger_info.didaq_info.beam_mask
 
         return mattak.Dataset.EventInfo(
             eventNumber=hdr.event_number,
@@ -226,13 +323,12 @@ class Dataset(mattak.Dataset.AbstractDataset):
             pps=hdr.pps_num,
             radiantStartWindows=radiantStartWindows,
             sampleRate=sampleRate,
-            radiantThrs=radiantThrs,
-            lowTrigThrs=lowTrigThrs,
-            lowphasedTrigThrs=lowphasedTrigThrs,
             hasWaveforms=self.ds.rawAvailable(),
             readoutDelay=readout_delay,
-            didaqCoinThrs=didaqCoinThrs,
-            didaqPhasedTrigThrs=didaqPhasedTrigThrs,
+            didaqStartOffsets=didaqStartOffsets,
+            didaqChannelMask=didaqChannelMask,
+            didaqBeamMask=didaqBeamMask,
+            **daq_thresholds,
         )
 
 

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -35,6 +35,11 @@ cast_int16_t  = cppyy.gbl.cast_int16_t
 def isNully(p):
     return p is None or ROOT.AddressOf(p) == 0 or cppyy.gbl.is_nully(p)
 
+def _read(obj):
+    try:
+        return numpy.array(obj)
+    except AttributeError:
+        return None
 
 def _check_digitizer_enum_in_sync():
     """ Sanity check that `mattak.Dataset.Digitizer` (python) and `mattak::Dataset::digitizer`
@@ -160,17 +165,22 @@ class Dataset(mattak.Dataset.AbstractDataset):
         radiantThrs = None
         lowTrigThrs = None
         lowphasedTrigThrs = None
+        didaqCoinThrs = None
+        didaqPhasedTrigThrs = None
         if self.__read_daq_status:
             daq_status = self.ds.status()
-            radiantThrs = numpy.array(daq_status.radiant_thresholds)
-            try:
-                lowTrigThrs = numpy.array(daq_status.lt_trigger_thresholds)
-            except AttributeError:
-                lowTrigThrs = numpy.array(daq_status.lt_coinc_trigger_thresholds)
-            try:
-                lowphasedTrigThrs = numpy.array(daq_status.lt_phased_trigger_thresholds)
-            except AttributeError:
-                lowphasedTrigThrs = None
+
+            radiantThrs = _read(daq_status.radiant_thresholds)
+
+            lowTrigThrs = _read(daq_status.lt_trigger_thresholds)
+            if lowTrigThrs is None:
+                lowTrigThrs = _read(daq_status.lt_coinc_trigger_thresholds)
+
+            lowphasedTrigThrs = _read(daq_status.lt_phased_trigger_thresholds)
+
+            didaqCoinThrs = _read(daq_status.didaq_coin_thresholds)
+            didaqPhasedTrigThrs = _read(daq_status.didaq_phased_trigger_thresholds)
+
 
         # now use Dataset's faster sample rate getter
         sampleRate = self.ds.radiantSampleRate() / 1000
@@ -220,7 +230,10 @@ class Dataset(mattak.Dataset.AbstractDataset):
             lowTrigThrs=lowTrigThrs,
             lowphasedTrigThrs=lowphasedTrigThrs,
             hasWaveforms=self.ds.rawAvailable(),
-            readoutDelay=readout_delay)
+            readoutDelay=readout_delay,
+            didaqCoinThrs=didaqCoinThrs,
+            didaqPhasedTrigThrs=didaqPhasedTrigThrs,
+        )
 
 
     def eventInfo(self) -> Union[Optional[mattak.Dataset.EventInfo],Sequence[Optional[mattak.Dataset.EventInfo]]]:

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -56,7 +56,7 @@ _DAQ_STATUS_THRESHOLD_FIELDS = {
 }
 
 
-def _read_daq_status_thresholds(daq_status) -> dict:
+def _read_daq_status_thresholds(daq_status, digitizer) -> dict:
     """
     Read the per-channel/per-beam threshold arrays off a `mattak::DAQStatus` object.
 
@@ -79,6 +79,15 @@ def _read_daq_status_thresholds(daq_status) -> dict:
     values = {}
     for field_name, candidate_attrs in _DAQ_STATUS_THRESHOLD_FIELDS.items():
         value = None
+
+        # this also keeps "unused" thresholds None
+        if digitizer == mattak.Dataset.Digitizer.DIDAQ:
+            if not field_name.startswith('didaq'):
+                continue
+        else:
+            if field_name.startswith('didaq'):
+                continue
+
         for attr in candidate_attrs:
             if hasattr(daq_status, attr):
                 value = _read(getattr(daq_status, attr))
@@ -278,7 +287,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
 
         daq_thresholds = {field_name: None for field_name in _DAQ_STATUS_THRESHOLD_FIELDS}
         if self.__read_daq_status:
-            daq_thresholds = _read_daq_status_thresholds(self.ds.status())
+            daq_thresholds = _read_daq_status_thresholds(self.ds.status(), self.digitizer)
 
         # now use Dataset's faster sample rate getter
         sampleRate = self.ds.sampleRate() / 1000

--- a/py/mattak/backends/pyroot/dataset.py
+++ b/py/mattak/backends/pyroot/dataset.py
@@ -36,6 +36,23 @@ def isNully(p):
     return p is None or ROOT.AddressOf(p) == 0 or cppyy.gbl.is_nully(p)
 
 
+def _check_digitizer_enum_in_sync():
+    """ Sanity check that `mattak.Dataset.Digitizer` (python) and `mattak::Dataset::digitizer`
+    (C++, src/mattak/Dataset.h) still declare the exact same members. A mismatch means the
+    installed libmattak and the mattak python package come from different versions. """
+    cpp_enum = ROOT.mattak.Dataset.digitizer
+    cpp_members = {name: int(getattr(cpp_enum, name)) for name in dir(cpp_enum) if name[0].isupper()}
+    py_members = {member.name: int(member.value) for member in mattak.Dataset.Digitizer}
+    if cpp_members != py_members:
+        raise RuntimeError(
+            f"mattak.Dataset.Digitizer (python, {py_members}) is out of sync with "
+            f"mattak::Dataset::digitizer (C++, {cpp_members}). Update mattak/Dataset.py to match "
+            "src/mattak/Dataset.h.")
+
+
+_check_digitizer_enum_in_sync()
+
+
 class Dataset(mattak.Dataset.AbstractDataset):
 
     def __init__(self, station : int, run : int, data_path : str,
@@ -97,6 +114,7 @@ class Dataset(mattak.Dataset.AbstractDataset):
 
         self.data_path = data_path
         self.full = self.ds.isFullDataset()
+        self.digitizer = mattak.Dataset.Digitizer(int(self.ds.getDigitizer()))
         self.setEntries(0)
 
         logger.debug("We think we found station %d run %d", self.station, self.run)
@@ -217,19 +235,21 @@ class Dataset(mattak.Dataset.AbstractDataset):
         if isNully(wf):
             return None
 
-        if wf.bytes_per_sample:
+        if self.digitizer == mattak.Dataset.Digitizer.DIDAQ:
             wfs = numpy.frombuffer(cast_uint8_t(wf.didaq_data), dtype="uint8",
-                            count=self.NUM_CHANNELS * 4096).reshape(self.NUM_CHANNELS, 4096)
-            wfs = wfs[:, :767]
+                count=self.NUM_CHANNELS * wf.buffer_length).reshape(
+                    self.NUM_CHANNELS, wf.buffer_length)
         else:
 
             if calibrated:
                 wfs = numpy.frombuffer(cppyy.ll.cast['double*'](wf.radiant_data), dtype="float64",
-                                count=self.NUM_CHANNELS * self.NUM_WF_SAMPLES).reshape(self.NUM_CHANNELS, self.NUM_WF_SAMPLES)
+                    count=self.NUM_CHANNELS * wf.buffer_length).reshape(
+                        self.NUM_CHANNELS, wf.buffer_length)
             else:
                 # FS: I think a np.copy is not necessary here because we do it in wfs()
                 wfs = numpy.frombuffer(cast_int16_t(wf.radiant_data), dtype="int16",
-                                count=self.NUM_CHANNELS * self.NUM_WF_SAMPLES).reshape(self.NUM_CHANNELS, self.NUM_WF_SAMPLES)
+                    count=self.NUM_CHANNELS * wf.buffer_length).reshape(
+                        self.NUM_CHANNELS, wf.buffer_length)
         return wfs
 
 
@@ -245,15 +265,15 @@ class Dataset(mattak.Dataset.AbstractDataset):
         if self.last - self.first < 0:
             return None
 
-        out = numpy.zeros((self.last - self.first, self.NUM_CHANNELS, self.NUM_WF_SAMPLES), dtype='float64' if calibrated else 'int16')
+        out = None
         for entry in range(self.first, self.last):
             this_wfs = self._wfs(entry, calibrated)
             if this_wfs is not None:
+                if out is None:
+                    out = numpy.zeros((self.last - self.first, *this_wfs.shape), dtype=this_wfs.dtype)
                 out[entry-self.first][:][:] = this_wfs
 
-        out = numpy.asarray(out, dtype=float)
-
-        return out
+        return numpy.asarray(out, dtype=float)
 
 
     def _iterate(

--- a/py/mattak/backends/uproot/dataset.py
+++ b/py/mattak/backends/uproot/dataset.py
@@ -210,6 +210,8 @@ class Dataset(mattak.Dataset.AbstractDataset):
                 ds_tree = self.combined_tree if skip_incomplete else self.full_daq_tree
                 self._dss, self.ds_branch =  read_tree(ds_tree, daqstatus_tree_names)
 
+        self.digitizer = self._check_digitizer_support()
+
         if station == 0 and run == 0 or self.data_path_is_file:
             self.station = int(self._hds['station_number'].array(entry_start=0, entry_stop=1)[0])
             self.run = int(self._hds['run_number'].array(entry_start=0, entry_stop=1)[0])
@@ -241,6 +243,36 @@ class Dataset(mattak.Dataset.AbstractDataset):
             self.has_calib = True
         else:
             self.has_calib = False
+
+    def _check_digitizer_support(self) -> mattak.Dataset.Digitizer:
+        """ Peek at the first event's `bytes_per_sample` (no waveform samples are read) to figure
+        out which digitizer wrote this run, and fail fast if it's not RADIANT.
+
+        The uproot backend only knows how to interpret `radiant_data`; DiDAQ support
+        (`didaq_data`) was only added to the pyroot backend, since the uproot backend is being
+        phased out and kept around just for reading older, RADIANT-only data.
+        """
+        if self._wfs is None:
+            return mattak.Dataset.Digitizer.Unknown
+
+        try:
+            bytes_per_sample = self._wfs["mattak::IWaveforms/bytes_per_sample"].array(
+                entry_start=0, entry_stop=1, library="np")
+        except uproot.exceptions.KeyInFileError:
+            # branch predates the introduction of this field entirely -> old, RADIANT-only data
+            return mattak.Dataset.Digitizer.RADIANT
+
+        if not len(bytes_per_sample):
+            return mattak.Dataset.Digitizer.Unknown
+
+        digitizer = mattak.Dataset.digitizer_from_bytes_per_sample(int(bytes_per_sample[0]))
+        if digitizer == mattak.Dataset.Digitizer.DIDAQ:
+            raise NotImplementedError(
+                "This run was recorded with the DiDAQ digitizer, which the uproot backend does "
+                "not support. Use the pyroot backend instead "
+                "(`mattak.Dataset.Dataset(..., backend='pyroot')`).")
+
+        return digitizer
 
     def _read_run_info(self):
         # try to get the run info, if we're using combined tree, try looking in there

--- a/scripts/daq/rno-g-autoconverter
+++ b/scripts/daq/rno-g-autoconverter
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 ROOT_DATA_DIR="/data"
 INGRESS="${ROOT_DATA_DIR}/ingress/"
 ARCHIVED="${ROOT_DATA_DIR}/archived/"

--- a/scripts/daq/rno-g-convert-run
+++ b/scripts/daq/rno-g-convert-run
@@ -106,7 +106,7 @@ then
   read -r list_header < "${ROOTIFIED_LIST}"
   if [ "${list_header}" != "${ROOTIFIED_LIST_HEADER}" ]
   then
-    echo "output directory found, but rootified-list.txt is not in the expected format, reconverting"
+    echo "Output directory found, but rootified-list.txt is not in the expected format, reconverting"
   else
     # Only a clean "nothing changed" skips the conversion. If in doubt convert:
     # a missed update means the run never ships south, a needless one costs CPU.
@@ -121,6 +121,7 @@ fi
 mkdir -p "${OUTDIR}"
 
 if [ ${NEED_TO_UPDATE} -eq 1 ] ; then
+  echo "Converting ${INDIR}"
 
   # Look for the voltage calibration file already
   # existing in the output directory
@@ -158,7 +159,8 @@ if [ ${NEED_TO_UPDATE} -eq 1 ] ; then
             --destination_folder "${OUTDIR}" &>> "${OUTDIR}/voltage_calibration.log" \
     || true; } \
     && echo "Create Monitoring data" \
-    && python3 "${SCRIPT_DIR}/mon_write.py" "${OUTDIR}" &>> "${OUTDIR}/monitoring.log" \
+    && { python3 "${SCRIPT_DIR}/mon_write.py" "${OUTDIR}" &>> "${OUTDIR}/monitoring.log" \
+       || echo "... failed."; false ; } \
     && echo "Conversion complete!"
 
   exit 1

--- a/scripts/daq/rno-g-convert-run
+++ b/scripts/daq/rno-g-convert-run
@@ -9,7 +9,11 @@ FORCE=${3-0}
 STATION_OVERRIDE=${4--1}
 RUN_OVERRIDE=${5--1}
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${RNO_G_INSTALL_DIR}" ]]; then
+  echo "RNO_G_INSTALL_DIR is not set. Can not locate mon_write.py, please set. Exit.."
+  exit 1
+fi
+SCRIPT_DIR="${RNO_G_INSTALL_DIR}/bin"
 
 if [ "${INDIR}" = "${OUTDIR}" ];
 then

--- a/scripts/daq/rno-g-convert-run
+++ b/scripts/daq/rno-g-convert-run
@@ -76,7 +76,7 @@ if [ ${NEED_TO_UPDATE} -eq 1 ] ; then
     && rno-g-convert ped "${OUTDIR}/pedestal.root" "${INDIR}"/pedestals.dat* \
     || true; } \
     && echo "Converting runinfo" \
-    && rno-g-convert runinfo "${OUTDIR}/runinfo.root" "${INDIR}/aux ${STATION_OVERRIDE} ${RUN_OVERRIDE}" \
+    && rno-g-convert runinfo "${OUTDIR}/runinfo.root" "${INDIR}/aux" "${STATION_OVERRIDE}" "${RUN_OVERRIDE}" \
     && echo "Copying aux and cfg"  \
     && cp -p -r "${INDIR}/aux"  "${OUTDIR}"/ \
     && cp -p -r "${INDIR}/cfg"  "${OUTDIR}"/ \

--- a/scripts/daq/rno-g-convert-run
+++ b/scripts/daq/rno-g-convert-run
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # don't expand globs to themselves if no match
 shopt -s nullglob
@@ -65,7 +65,7 @@ if [ ${NEED_TO_UPDATE} -eq 1 ] ; then
   fi
 
   # Check if we are DiDAQ
-  grep -iq didaq ~/station25/run26064/aux/runinfo.txt
+  grep -iq didaq "${INDIR}/aux/runinfo.txt"
   ON_DIDAQ=$(( !$? ))
 
   echo "Making rootified list" \

--- a/scripts/daq/rno-g-convert-run
+++ b/scripts/daq/rno-g-convert-run
@@ -122,10 +122,19 @@ if [ ${NEED_TO_UPDATE} -eq 1 ] ; then
   # existing in the output directory
   calibration_file=("${OUTDIR}"/volCalConsts*)
 
+  # Waveforms and headers carry the run's event number, so rno-g-convert can
+  # extend the existing ROOT files with whatever arrived since the last pass
+  # rather than converting the whole run again. A forced run has to rebuild them
+  # from scratch, which is the whole point of forcing it.
+  # (daqstatus and pedestals have no event number and are small, so they keep
+  # being converted in full.)
+  UPDATE=--update
+  [ ${FORCE} -ne 0 ] && UPDATE=
+
   echo "Converting waveforms"  \
-    && rno-g-convert wf "${OUTDIR}/waveforms.root" "${INDIR}"/waveforms/* \
+    && rno-g-convert ${UPDATE} wf "${OUTDIR}/waveforms.root" "${INDIR}"/waveforms/* \
     && echo "Converting headers"  \
-    && rno-g-convert hd "${OUTDIR}/headers.root" "${INDIR}"/header/* \
+    && rno-g-convert ${UPDATE} hd "${OUTDIR}/headers.root" "${INDIR}"/header/* \
     && echo "Converting daqstatus" \
     && rno-g-convert ds "${OUTDIR}/daqstatus.root" "${INDIR}"/daqstatus/* \
     && echo "Converting pedestals" \

--- a/scripts/daq/rno-g-convert-run
+++ b/scripts/daq/rno-g-convert-run
@@ -55,6 +55,15 @@ if [ ${NEED_TO_UPDATE} -eq 1 ] ; then
   # existing in the output directory
   calibration_file=("${OUTDIR}"/volCalConsts*)
 
+  if [ ! -f "${INDIR}/aux/runinfo.txt" ]; then
+    echo "Did not find runinfo.txt for input dir ${INDIR}. Exit..."
+    exit 1;
+  fi
+
+  # Check if we are DiDAQ
+  grep -iq didaq ~/station25/run26064/aux/runinfo.txt
+  ON_DIDAQ=$(( !$? ))
+
   echo "Making rootified list" \
     && find "${INDIR}" | sort -o "$tmpfile" \
     && echo "Converting waveforms"  \
@@ -63,15 +72,16 @@ if [ ${NEED_TO_UPDATE} -eq 1 ] ; then
     && rno-g-convert hd "${OUTDIR}/headers.root" "${INDIR}"/header/* \
     && echo "Converting daqstatus" \
     && rno-g-convert ds "${OUTDIR}/daqstatus.root" "${INDIR}"/daqstatus/* \
-    && echo "Converting pedestals" \
+    && { [ $ON_DIDAQ -eq 0 ] && echo "Converting pedestals" \
     && rno-g-convert ped "${OUTDIR}/pedestal.root" "${INDIR}"/pedestals.dat* \
+    || true; } \
     && echo "Converting runinfo" \
     && rno-g-convert runinfo "${OUTDIR}/runinfo.root" "${INDIR}/aux ${STATION_OVERRIDE} ${RUN_OVERRIDE}" \
     && echo "Copying aux and cfg"  \
     && cp -p -r "${INDIR}/aux"  "${OUTDIR}"/ \
     && cp -p -r "${INDIR}/cfg"  "${OUTDIR}"/ \
     && install -m 0644 "$tmpfile" "${OUTDIR}/rootified-list.txt" \
-    && { [ -f "${INDIR}/bias_scan.dat.gz" ] && [ ${#calibration_file[@]} -ne 1 ] \
+    && { [ $ON_DIDAQ -eq 0 ] && [ -f "${INDIR}/bias_scan.dat.gz" ] && [ ${#calibration_file[@]} -ne 1 ] \
     && echo "Doing Voltage calibration" \
     && python3 "${SCRIPT_DIR}/convert_bias_scan_to_calibration.py" \
             "${INDIR}/bias_scan.dat.gz" --pedestal_file "${OUTDIR}/pedestal.root" \

--- a/scripts/daq/rno-g-convert-station
+++ b/scripts/daq/rno-g-convert-station
@@ -15,8 +15,7 @@ fi
 echo "raw dir is ${RAWDIR}/station$STATION"
 echo "output dir is ${ROOTDIR}/station$STATION"
 
-runs=`ls $RAWDIR/station$STATION/ | grep run`
+runs=$(ls $RAWDIR/station$STATION/ | grep run)
 echo $runs
 
 parallel --jobs $NPROCS rno-g-convert-run $RAWDIR/station$STATION/{}  ${ROOTDIR}/station$STATION/{} $FORCE ::: $runs
-

--- a/scripts/monitoring/mon_read.py
+++ b/scripts/monitoring/mon_read.py
@@ -1,6 +1,8 @@
 """
 Example script to read monitoring information from a ROOT file created by mon_write.py.
 It demonstrates how to access event-level and run-level information stored in the monitoring.root file format.
+
+Handles both RADIANT and DiDAQ runs, telling the two apart by the trigger types stored in the file.
 """
 import ROOT
 import cppyy
@@ -13,6 +15,16 @@ import mattak.backends.pyroot.dataset
 
 import matplotlib.pyplot as plt
 import numpy as np
+
+# (plot label, RunSummary field) per trigger type. mon_write.py fills only the spectra of the
+# digitizer the run was taken with, FORCE being the one trigger type common to both.
+SPECTRA_RADIANT = [
+    ("Force", "avg_spectrum_force"), ("LT", "avg_spectrum_lt"),
+    ("RF0", "avg_spectrum_rf0"), ("RF1", "avg_spectrum_rf1")]
+SPECTRA_DIDAQ = [
+    ("Force", "avg_spectrum_force"), ("Coinc0", "avg_spectrum_didaq_coinc0"),
+    ("Coinc1", "avg_spectrum_didaq_coinc1"), ("Surf up", "avg_spectrum_didaq_surf_up"),
+    ("Surf down", "avg_spectrum_didaq_surf_down"), ("Deep phased", "avg_spectrum_didaq_deep_phased")]
 
 
 def convert_rdf_to_numpy(rdf):
@@ -36,8 +48,16 @@ f = ROOT.TFile(sys.argv[1], "READ")
 event_tree = f.Get("events")
 run_summary = f.Get("RunSummary")
 
+# The DiDAQ spectra only exist (are only filled) for a DiDAQ run, and vice versa
+is_didaq = len(run_summary.avg_spectrum_didaq_deep_phased) > 0
+is_radiant = len(run_summary.avg_spectrum_lt) > 0
+
+if not is_radiant and not is_didaq:
+    raise ValueError("Could not identify digitizer, now phased array triggers found ...")
+
 print("Station number:", run_summary.station_number)
 print("Number of events:", run_summary.n_events)
+print("Digitizer:", "DIDAQ" if is_didaq else "RADIANT")
 
 block_offsets = []
 # Access option 1: directly from the tree
@@ -48,11 +68,13 @@ for entry in event_tree:
     rms = np.array(event_summary.rms, dtype=np.float32)
     block_offsets.append(np.array(event_summary.block_offset))
 
-block_offsets = np.array(block_offsets, dtype=np.uint16)
-fig, ax = plt.subplots(1, 1)
-ax.hist(block_offsets[:, 0], label="Channel 0")
-ax.set_xlabel("max. abs. block offset")
-ax.legend()
+# Block offsets are RADIANT-only, mon_write.py leaves them empty for DiDAQ events
+if not is_didaq:
+    block_offsets = np.array(block_offsets, dtype=np.uint16)
+    fig, ax = plt.subplots(1, 1)
+    ax.hist(block_offsets[:, 0], label="Channel 0")
+    ax.set_xlabel("max. abs. block offset")
+    ax.legend()
 
 # Access option 2: via ROOT's RDataFrame - CURRENTLY NOT RECOMMANDED AS INT TYPES ARE NOT PROPERLY CONVERTED TO PYTHON INT
 rf = ROOT.RDataFrame(event_tree)
@@ -62,9 +84,15 @@ data = convert_rdf_to_numpy(rf)
 # Access RunSummary information
 fig, ax = plt.subplots(1, 1)
 
-ax.plot(np.array(run_summary.frequencies), np.array(run_summary.avg_spectrum_force[0]))
-ax.set_xlabel("Frequency (Hz)")
-ax.set_ylabel("RMS")
-ax.legend()
+frequencies = np.array(run_summary.frequencies)
+for label, field in (SPECTRA_DIDAQ if is_didaq else SPECTRA_RADIANT):
+    spectrum = getattr(run_summary, field)
+    if len(spectrum):  # empty if this trigger type did not fire during the run
+        ax.plot(frequencies, np.array(spectrum[0]), lw=1, label=label)
+
+ax.set_xlabel("Frequency (GHz)")
+ax.set_ylabel("Average spectrum")
+ax.set_yscale("log")
+ax.legend(title="Channel 0")
 
 plt.show()

--- a/scripts/monitoring/mon_write.py
+++ b/scripts/monitoring/mon_write.py
@@ -31,7 +31,6 @@ from NuRadioReco.utilities import logging as nu_logging
 nu_logging.set_general_log_level(nu_logging.ERROR)  # suppress warnings from NuRadio
 
 NR_CHANNELS = 24
-NR_SAMPESRATES = 2048
 OFFSET_BLOCK_SIZE = 128
 
 def calculate_glitch_test_statistic(wf):
@@ -75,7 +74,7 @@ def get_run_summary(dataset):
     return run_summary
 
 
-def write_event_summary(event_summary, event_info, wfs):
+def write_event_summary(event_summary, event_info, wfs, is_didaq=0):
     """Populate one ``EventSummary`` from header metadata and waveform data.
 
     For each channel, this computes RMS, max absolute amplitude, a glitch score,
@@ -90,20 +89,21 @@ def write_event_summary(event_summary, event_info, wfs):
     amax = np.max(np.abs(wfs), axis=1).astype(np.uint16)
     assign_numpy_array_to_cpp_vector(event_summary.max_abs_amplitude, amax)
 
-    glitching_test_statitic = np.zeros(len(wfs), dtype=np.float32)
-    block_offsets = np.zeros(len(wfs), dtype=np.uint16)
+    if not is_didaq:
+        glitching_test_statitic = np.zeros(len(wfs), dtype=np.float32)
+        block_offsets = np.zeros(len(wfs), dtype=np.uint16)
 
-    for i, wf in enumerate(wfs):
+        for i, wf in enumerate(wfs):
 
-        glitching_test_statitic[i] = calculate_glitch_test_statistic(wf)
-        offsets = fit_block_offsets(
-            wf, block_size=OFFSET_BLOCK_SIZE, sampling_rate=event_info.sampleRate,
-            max_frequency=50*units.MHz, mode='auto', return_trace=False,
-            maxiter=5, tol=1e-6)
-        block_offsets[i] = np.abs(offsets).max()  # take the max. abs. offset as a summary statistic for the event
+            glitching_test_statitic[i] = calculate_glitch_test_statistic(wf)
+            offsets = fit_block_offsets(
+                wf, block_size=OFFSET_BLOCK_SIZE, sampling_rate=event_info.sampleRate,
+                max_frequency=50*units.MHz, mode='auto', return_trace=False,
+                maxiter=5, tol=1e-6)
+            block_offsets[i] = np.abs(offsets).max()  # take the max. abs. offset as a summary statistic for the event
 
-    assign_numpy_array_to_cpp_vector(event_summary.glitching_test_statitic, glitching_test_statitic)
-    assign_numpy_array_to_cpp_vector(event_summary.block_offset, block_offsets)
+        assign_numpy_array_to_cpp_vector(event_summary.glitching_test_statitic, glitching_test_statitic)
+        assign_numpy_array_to_cpp_vector(event_summary.block_offset, block_offsets)
 
 if __name__ == "__main__":
 
@@ -128,9 +128,9 @@ if __name__ == "__main__":
     monitoring_file_path = run_dir / "monitoring.root"
 
     dataset = mattak.Dataset.Dataset(data_path=sys.argv[1], backend='pyroot')
+    is_didaq = dataset.digitizer == mattak.Dataset.Digitizer.DIDAQ
 
     try:
-
         # We allow to update an existing monitoring file. This is needed
         # as the rno-g-autoconverter script may be run multiple times on the
         # same run directory as new data arrives, and we want to avoid losing
@@ -168,8 +168,9 @@ if __name__ == "__main__":
             update_file = False
 
         event_counts = defaultdict(int)
-        avg_spectra = defaultdict(lambda:
-            np.zeros((NR_CHANNELS, NR_SAMPESRATES // 2 + 1), dtype=np.float32))
+        # Shape (NR_CHANNELS, n_samples // 2 + 1) is only known once we see the first
+        # waveform, since n_samples depends on the digitizer (RADIANT vs. DIDAQ).
+        avg_spectra = defaultdict(lambda: np.zeros_like(specs))
 
         update_needed = False
         rms = []
@@ -184,7 +185,7 @@ if __name__ == "__main__":
 
             update_needed = True
 
-            write_event_summary(event_summary, ev, wfs)
+            write_event_summary(event_summary, ev, wfs, is_didaq)
             t.Fill()
 
             event_counts["total"] += 1

--- a/scripts/monitoring/mon_write.py
+++ b/scripts/monitoring/mon_write.py
@@ -33,6 +33,23 @@ nu_logging.set_general_log_level(nu_logging.ERROR)  # suppress warnings from NuR
 NR_CHANNELS = 24
 OFFSET_BLOCK_SIZE = 128
 
+# Per-trigger-type run summary fields:
+#   (triggerType as returned by mattak.Dataset, RunSummary spectrum field, RunSummary counter field)
+# The trigger types are the ones produced by `_get_trigger_type` in the pyroot backend. A run uses
+# a single digitizer, so either only the RADIANT/LT entries or only the DIDAQ entries ever fire
+# (FORCE is common to both); the unused ones are simply never filled.
+TRIGGER_SUMMARY_FIELDS = (
+    ("FORCE", "avg_spectrum_force", "n_forced_triggers"),
+    ("LT", "avg_spectrum_lt", "n_lt_triggers"),
+    ("RADIANT0", "avg_spectrum_rf0", "n_rf0_triggers"),
+    ("RADIANT1", "avg_spectrum_rf1", "n_rf1_triggers"),
+    ("DIDAQ_COINC0", "avg_spectrum_didaq_coinc0", "n_didaq_coinc0_triggers"),
+    ("DIDAQ_COINC1", "avg_spectrum_didaq_coinc1", "n_didaq_coinc1_triggers"),
+    ("DIDAQ_SURF_UP", "avg_spectrum_didaq_surf_up", "n_didaq_surf_up_triggers"),
+    ("DIDAQ_SURF_DOWN", "avg_spectrum_didaq_surf_down", "n_didaq_surf_down_triggers"),
+    ("DIDAQ_DEEP_PHASED", "avg_spectrum_didaq_deep_phased", "n_didaq_deep_phased_triggers"),
+)
+
 def calculate_glitch_test_statistic(wf):
     """Return the per-channel glitch test statistic for one waveform trace.
 
@@ -212,11 +229,24 @@ if __name__ == "__main__":
 
             When appending to an existing file, previously stored averages are combined
             with newly accumulated spectra using event-count weighted means.
+
+            Trigger types without any new event are left untouched: their accumulated spectrum is
+            all-zero, so writing it would either wipe what is already stored (update) or waste
+            space on a trigger type this run does not have at all (e.g. all the DIDAQ ones for a
+            RADIANT run).
             """
+            n_new_events = event_counts.get(trigger_type, 0)
+            if not n_new_events:
+                return
+
+            # Not the same as `update_file`: a trigger type that saw its first event only now has
+            # nothing stored yet even though we are updating an existing file.
+            has_stored_spectra = len(run_summary_obj) == NR_CHANNELS
+
             for i in range(NR_CHANNELS):
-                if update_file and event_counts.get(trigger_type, 0):
-                    w1 = prev_event_number / (prev_event_number + event_counts[trigger_type])
-                    w2 = event_counts[trigger_type] / (prev_event_number + event_counts[trigger_type])
+                if has_stored_spectra:
+                    w1 = prev_event_number / (prev_event_number + n_new_events)
+                    w2 = n_new_events / (prev_event_number + n_new_events)
 
                     avg_spectra[trigger_type][i] = (
                         avg_spectra[trigger_type][i] * w2 + np.array(run_summary_obj[i]) * w1)
@@ -224,23 +254,22 @@ if __name__ == "__main__":
                 vec = ROOT.std.vector("float")()
                 assign_numpy_array_to_cpp_vector(vec, avg_spectra[trigger_type][i])
 
-                if not update_file:
-                    run_summary_obj.push_back(vec)
-                else:
+                if has_stored_spectra:
                     run_summary_obj[i] = vec
+                else:
+                    run_summary_obj.push_back(vec)
 
         fill_spectra(run_summary.avg_spectrum, "total", run_summary.n_events)
-        fill_spectra(run_summary.avg_spectrum_force, "FORCE", run_summary.n_forced_triggers)
-        fill_spectra(run_summary.avg_spectrum_rf0, "RADIANT0", run_summary.n_rf0_triggers)
-        fill_spectra(run_summary.avg_spectrum_rf1, "RADIANT1", run_summary.n_rf1_triggers)
-        fill_spectra(run_summary.avg_spectrum_lt, "LT", run_summary.n_lt_triggers)
+        for trigger_type, spectrum_field, counter_field in TRIGGER_SUMMARY_FIELDS:
+            fill_spectra(getattr(run_summary, spectrum_field), trigger_type,
+                         getattr(run_summary, counter_field))
 
-        # Adding event counts to run summary
+        # Adding event counts to run summary. This has to happen after all `fill_spectra` calls,
+        # which weight the stored spectra with the event counts of the *previous* update.
         run_summary.n_events += event_counts.get("total", 0)
-        run_summary.n_forced_triggers += event_counts.get("FORCE", 0)
-        run_summary.n_rf0_triggers += event_counts.get("RADIANT0", 0)
-        run_summary.n_rf1_triggers += event_counts.get("RADIANT1", 0)
-        run_summary.n_lt_triggers += event_counts.get("LT", 0)
+        for trigger_type, _, counter_field in TRIGGER_SUMMARY_FIELDS:
+            setattr(run_summary, counter_field,
+                    getattr(run_summary, counter_field) + event_counts.get(trigger_type, 0))
 
         t.Write("", ROOT.TObject.kOverwrite)
         run_summary.Write("RunSummary", ROOT.TObject.kOverwrite)

--- a/scripts/services/tmux_follow_services.sh
+++ b/scripts/services/tmux_follow_services.sh
@@ -18,7 +18,7 @@
 #
 # Usage: tmux_follow_services.sh [-p PANES_PER_WINDOW] [-h]
 
-STATIONS="23 11 22 12 21 13 24 14"
+STATIONS="11 12 13 14 21 22 23 24"
 SESSION="autoconverter"
 
 # usage: Print help text describing the script and its options.

--- a/scripts/voltage_calibration/makeFakeData.C
+++ b/scripts/voltage_calibration/makeFakeData.C
@@ -1,88 +1,86 @@
 
-/* This makes some fake data */ 
+/* This makes some fake data */
 
-void makeFakeData(int station = 12345, int run = 1, int nsecs = 3600, double event_rate = 1, double daq_status_interval = 10, double sensors_interval = 10) 
+void makeFakeData(int station = 12345, int run = 1, int nsecs = 3600, double event_rate = 1, double daq_status_interval = 10, double sensors_interval = 10)
 {
 
-  const char * data_dir = getenv("RNO_G_DATA"); 
+  const char * data_dir = getenv("RNO_G_DATA");
 
   if (!data_dir)
   {
-    std::cerr << "Please define RNO_G_DATA" << std::endl; 
-    return ; 
+    std::cerr << "Please define RNO_G_DATA" << std::endl;
+    return ;
   }
 
-  TTimeStamp now; 
-  unsigned year, month, day; 
-  now.GetDate(true,0,&year,&month,&day); 
-  unsigned hr, min, sec; 
-  now.GetTime(true,0,&hr,&min,&sec); 
+  TTimeStamp now;
+  unsigned year, month, day;
+  now.GetDate(true,0,&year,&month,&day);
+  unsigned hr, min, sec;
+  now.GetTime(true,0,&hr,&min,&sec);
 
 
 
 
 
-  gSystem->mkdir(Form("%s/station_%d/runs/run_%05d",data_dir, station, run), true); 
-  gSystem->mkdir(Form("%s/station_%d/sensors/%u/%02u/%02u", data_dir, station, year, month, day), true); 
+  gSystem->mkdir(Form("%s/station_%d/runs/run_%05d",data_dir, station, run), true);
+  gSystem->mkdir(Form("%s/station_%d/sensors/%u/%02u/%02u", data_dir, station, year, month, day), true);
 
-  TFile wf_file(Form("%s/station_%d/runs/run_%05d/waveforms.root", data_dir, station, run),"RECREATE"); 
-  auto wf_tree = new TTree("waveforms","waveforms"); 
+  TFile wf_file(Form("%s/station_%d/runs/run_%05d/waveforms.root", data_dir, station, run),"RECREATE");
+  auto wf_tree = new TTree("waveforms","waveforms");
   auto wf= new mattak::Waveforms;
-  wf_tree->Branch("waveforms", &wf); 
+  wf_tree->Branch("waveforms", &wf);
 
 
-  TFile hd_file(Form("%s/station_%d/runs/run_%05d/header.root", data_dir, station, run),"RECREATE"); 
-  auto hd_tree = new TTree("header","header"); 
+  TFile hd_file(Form("%s/station_%d/runs/run_%05d/header.root", data_dir, station, run),"RECREATE");
+  auto hd_tree = new TTree("header","header");
   auto hd = new mattak::Header;
-  hd_tree->Branch("header",&hd); 
+  hd_tree->Branch("header",&hd);
 
-  TFile st_file(Form("%s/station_%d/runs/run_%05d/daqstatus.root", data_dir, station, run),"RECREATE"); 
-  auto st_tree = new TTree("daqstatus","daqstatus"); 
-  auto st = new mattak::DAQStatus; 
-  st_tree->Branch("daqstatus",&st); 
+  TFile st_file(Form("%s/station_%d/runs/run_%05d/daqstatus.root", data_dir, station, run),"RECREATE");
+  auto st_tree = new TTree("daqstatus","daqstatus");
+  auto st = new mattak::DAQStatus;
+  st_tree->Branch("daqstatus",&st);
 
-  TFile hk_file(Form("%s/station_%d/sensors/%d/%02u/%02u/%02u%02u%02u.root", data_dir, station, year, month, day, hr, min, sec),"RECREATE"); 
-  auto hk_tree = new TTree("sensors","sensors"); 
-  auto hk = new mattak::Sensors; 
-  hk_tree->Branch("sensors",&hk); 
+  TFile hk_file(Form("%s/station_%d/sensors/%d/%02u/%02u/%02u%02u%02u.root", data_dir, station, year, month, day, hr, min, sec),"RECREATE");
+  auto hk_tree = new TTree("sensors","sensors");
+  auto hk = new mattak::Sensors;
+  hk_tree->Branch("sensors",&hk);
 
 
-  double t0 = now.AsDouble(); 
+  double t0 = now.AsDouble();
 
-  double t = t0; 
-  gRandom->SetSeed(0); 
+  double t = t0;
+  gRandom->SetSeed(0);
 
   double last_sensors_t = 0;
   double last_status_t = 0;
 
-  hd->run_number= run; 
+  hd->run_number= run;
   hd->station_number = station;
-  wf->run_number= run; 
+  wf->run_number= run;
   wf->station_number = station;
 
-
-  hd->buffer_length = 2048;
   wf->buffer_length = 2048;
   hd->pretrigger_samples = 100;
   hd->trigger_info.rf_trigger =true;
   hd->trigger_info.radiant_trigger =true;
 
   int sysclk_rate = 100e6; // whatever
-  int sysclk_pps_offset = gRandom->Uniform(0,sysclk_rate); 
-  hd->sysclk = sysclk_pps_offset; 
+  int sysclk_pps_offset = gRandom->Uniform(0,sysclk_rate);
+  hd->sysclk = sysclk_pps_offset;
 
-  while (t < t0 + nsecs) 
+  while (t < t0 + nsecs)
   {
 
     if (t > last_sensors_t + sensors_interval)
     {
-      last_sensors_t = t; 
-      hk->readout_time = t + gRandom->Gaus(0,0.2); 
+      last_sensors_t = t;
+      hk->readout_time = t + gRandom->Gaus(0,0.2);
 
       hk->PV_voltage =  TMath::Min(0., 48 * sin ( t / (3600*24) )) + gRandom->Gaus(0,0.1) ; // whatever
       hk->PV_current =  TMath::Min(0., 1000*sin ( t / (3600*24) )) ; + gRandom->Gaus(0,100); // whatever
-      hk->battery_voltage = 24 + gRandom->Gaus(0,0.1); 
-      hk->battery_current = 1000 + gRandom->Gaus(0,100); 
+      hk->battery_voltage = 24 + gRandom->Gaus(0,0.1);
+      hk->battery_current = 1000 + gRandom->Gaus(0,100);
 
 
       hk->T_power_board = gRandom->Gaus(20,2);
@@ -90,56 +88,56 @@ void makeFakeData(int station = 12345, int run = 1, int nsecs = 3600, double eve
       hk->T_amps = gRandom->Gaus(20,2);
       hk->T_controller_board = gRandom->Gaus(20,2);
 
-      hk->radiant_current = gRandom->Gaus(2000,200); 
-      hk->lt_current = 0; 
-      hk->sbc_current = gRandom->Gaus(200,10); 
+      hk->radiant_current = gRandom->Gaus(2000,200);
+      hk->lt_current = 0;
+      hk->sbc_current = gRandom->Gaus(200,10);
 
-      hk->downhole_currents[0] = gRandom->Gaus(200,10); 
-      hk->downhole_currents[1] = gRandom->Gaus(200,10); 
-      hk->downhole_currents[2] = gRandom->Gaus(200,10); 
-      
-      hk->amp_currents[0] = gRandom->Gaus(200,10); 
-      hk->amp_currents[1] = gRandom->Gaus(200,10); 
-      hk->amp_currents[2] = gRandom->Gaus(200,10); 
-      hk->amp_currents[3] = gRandom->Gaus(200,10); 
-      hk->amp_currents[4] = gRandom->Gaus(200,10); 
-      hk->amp_currents[5] = gRandom->Gaus(200,10); 
+      hk->downhole_currents[0] = gRandom->Gaus(200,10);
+      hk->downhole_currents[1] = gRandom->Gaus(200,10);
+      hk->downhole_currents[2] = gRandom->Gaus(200,10);
 
-      hk->disk_space_SD_card = 100; 
-      hk->disk_space_internal = 1.1; 
-      hk->free_mem = 123.45; 
+      hk->amp_currents[0] = gRandom->Gaus(200,10);
+      hk->amp_currents[1] = gRandom->Gaus(200,10);
+      hk->amp_currents[2] = gRandom->Gaus(200,10);
+      hk->amp_currents[3] = gRandom->Gaus(200,10);
+      hk->amp_currents[4] = gRandom->Gaus(200,10);
+      hk->amp_currents[5] = gRandom->Gaus(200,10);
+
+      hk->disk_space_SD_card = 100;
+      hk->disk_space_internal = 1.1;
+      hk->free_mem = 123.45;
       hk->loadavg[0] =1;
       hk->loadavg[1] =1;
       hk->loadavg[2] =1;
       hk->cpu_uptime = t-t0-1000;
       hk->mcu_uptime = t-t0-1000;
 
-      hk->lte_rsrq = -5; 
-      hk->lte_rsrp = -90; 
-      hk->lte_rssi = -80; 
-      hk->lte_snr = -5; 
+      hk->lte_rsrq = -5;
+      hk->lte_rsrp = -90;
+      hk->lte_rssi = -80;
+      hk->lte_snr = -5;
 
-      hk_tree->Fill(); 
+      hk_tree->Fill();
     }
 
     if (t > last_status_t + daq_status_interval)
     {
-      last_status_t = t; 
-      st->readout_time = t+gRandom->Exp(0.1); 
+      last_status_t = t;
+      st->readout_time = t+gRandom->Exp(0.1);
 
-      //TODO: fill rest 
+      //TODO: fill rest
       //
-      st_tree->Fill(); 
+      st_tree->Fill();
     }
 
 
-    hd->event_number++; 
-    wf->event_number++; 
-    hd->trigger_number++; 
-    hd->readout_time = t+gRandom->Exp(0.1); 
-    hd->pps_num = int(t); 
+    hd->event_number++;
+    wf->event_number++;
+    hd->trigger_number++;
+    hd->readout_time = t+gRandom->Exp(0.1);
+    hd->pps_num = int(t);
 
-    //TODO: figure out last_pps and last_last_pps 
+    //TODO: figure out last_pps and last_last_pps
     hd->trigger_info.surface_trigger = gRandom->Rndm() < 0.1;
 
 
@@ -147,23 +145,22 @@ void makeFakeData(int station = 12345, int run = 1, int nsecs = 3600, double eve
     {
       for (int isamp = 0; isamp < mattak::k::num_radiant_samples; isamp++)
       {
-        wf->radiant_data[ichan][isamp] = gRandom->Gaus(2048,20); 
+        wf->radiant_data[ichan][isamp] = gRandom->Gaus(2048,20);
       }
     }
 
-    hd_tree->Fill(); 
-    wf_tree->Fill(); 
-    double dt = gRandom->Exp(event_rate); 
-    hd->sysclk += dt * sysclk_rate; 
-    t+= dt; 
-  }; 
+    hd_tree->Fill();
+    wf_tree->Fill();
+    double dt = gRandom->Exp(event_rate);
+    hd->sysclk += dt * sysclk_rate;
+    t+= dt;
+  };
 
 
   wf_file.Write();
-  hd_file.Write(); 
-  st_file.Write(); 
-  hk_file.Write(); 
+  hd_file.Write();
+  st_file.Write();
+  hk_file.Write();
 
 
-}; 
-
+};

--- a/scripts/voltage_calibration/makeFakeDataToTestVoltageCalibration.cc
+++ b/scripts/voltage_calibration/makeFakeDataToTestVoltageCalibration.cc
@@ -50,8 +50,6 @@ int main()
   wf->run_number= run;
   wf->station_number = station;
 
-
-  hd->buffer_length = 2048;
   wf->buffer_length = 2048;
   hd->pretrigger_samples = 100;
   hd->trigger_info.rf_trigger = true;

--- a/scripts/voltage_calibration/makeFakeDataToTestVoltageCalibrationWaveforms.cc
+++ b/scripts/voltage_calibration/makeFakeDataToTestVoltageCalibrationWaveforms.cc
@@ -18,7 +18,7 @@
   gcc makeFakeDataToTestVoltageCalibrationWaveforms.cc \
     -o makeFakeDataToTestVoltageCalibrationWaveforms.out -I $PWD/../install/include \
     -lmattak -L $PWD/../install/lib  $(root-config --libs) $(root-config --cflags) -Wall -lstdc++
-  
+
 */
 
 
@@ -65,8 +65,6 @@ int main()
   wf->run_number= run;
   wf->station_number = station;
 
-
-  hd->buffer_length = 2048;
   wf->buffer_length = 2048;
   hd->pretrigger_samples = 100;
   hd->trigger_info.rf_trigger = true;

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -177,7 +177,7 @@ int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, 
 
 int mattak::convert::makeRunInfo(const char *auxdir, const char * outfile, int station_override, int run_override)
 {
-  TFile of(outfile,"RECREATE");
+  TFile of(outfile, "RECREATE");
   RunInfo * ri = new RunInfo(auxdir);
   if (station_override > 0)
   {

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -3,6 +3,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <algorithm>
+#include <string>
 #include <vector>
 #include "TTree.h"
 #include "TFile.h"
@@ -25,32 +26,136 @@ template<> const char * getName<mattak::DAQStatus>() { return "daqstatus"; }
 template<> const char * getName<mattak::Pedestals>() { return "pedestals"; }
 
 
+/* Incremental (update) conversion.
+ *
+ * A run is converted over and over while it is being taken, each time gaining
+ * only the handful of raw files which arrived since. Waveforms and headers carry
+ * the run's sequential event number, so an existing output file already says
+ * where to continue: everything up to the event number of its last entry is
+ * converted. Raw events at or below that are skipped and the rest appended.
+ *
+ * That needs no bookkeeping beside the data, and it recovers by itself from an
+ * interrupted conversion: ROOT commits a tree by rewriting its key, so a
+ * converter which is killed part way leaves the tree at its last committed
+ * length, and the next pass simply resumes from the event number it finds there.
+ * It also guarantees the result stays ordered, since an event is only ever
+ * appended if it comes after everything already in the tree.
+ */
+
+/** The event number of a raw record, or -1 for types which do not have one
+ * (pedestals, daqstatus) and are therefore always converted in full. */
+template <typename Traw> static long long rawEventNumber(const Traw &) { return -1; }
+template<> long long rawEventNumber(const rno_g_waveform_t & raw) { return raw.event_number; }
+template<> long long rawEventNumber(const rno_g_header_t & raw) { return raw.event_number; }
+
+template <typename Troot> static long long eventNumberOf(const Troot *) { return -1; }
+template<> long long eventNumberOf(const mattak::Waveforms * wf) { return wf->event_number; }
+template<> long long eventNumberOf(const mattak::Header * hd) { return hd->event_number; }
+
+
+/** The event number of the last entry already in outfile, or -1 if it cannot be
+ * appended to (no such file, no such tree, empty, or a type without event
+ * numbers) and has to be written from scratch.
+ */
+template <typename Troot>
+static long long lastConvertedEvent(const char * outfile, const char * treename)
+{
+  if (access(outfile, R_OK)) return -1;
+
+  // Read-only on purpose: opening a TFile for writing rewrites its header, and
+  // most passes turn out to have nothing to add at all.
+  TFile * f = TFile::Open(outfile, "READ");
+  if (!f || f->IsZombie())
+  {
+    ::Error("mattak::convert", "Could not open %s, converting from scratch", outfile);
+    delete f;
+    return -1;
+  }
+
+  long long last = -1;
+  TTree * t = (TTree *) f->Get(treename);
+
+  if (t && t->GetEntries() > 0)
+  {
+    Troot * b = 0;
+    t->SetBranchAddress(treename, &b);
+    if (t->GetEntry(t->GetEntries() - 1) > 0) last = eventNumberOf<Troot>(b);
+
+    // Event numbers are sequential within a run and start at 0, so a complete
+    // tree holds exactly last+1 entries. If any are missing -- a raw file which
+    // could not be read on an earlier pass, one which turned up only after later
+    // events had been converted, or one which was truncated -- then they all sit
+    // below `last`, where appending would never reach them again, and only
+    // converting from scratch brings them back.
+    //
+    // Counting from 0 assumes the whole run is converted at once, which is what
+    // rno-g-convert-run does (it hands over the entire waveforms/ glob).
+    // Converting only a later subset of a run would look like a gap here and be
+    // rebuilt on every pass: still correct, just not incremental.
+    if (last >= 0 && t->GetEntries() != last + 1)
+    {
+      ::Error("mattak::convert",
+              "%s holds %lld entries but its last event is %lld, so some are missing; converting from scratch",
+              outfile, (long long) t->GetEntries(), last);
+      last = -1;
+    }
+  }
+
+  delete f;
+  return last;
+}
+
+
 template <typename Traw, int(*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
 static int convert_impl(
     int N, const char ** infiles, const char * outfile,
-    const char * treename, int station)
+    const char * treename, int station, bool update)
 {
+  if (!treename) treename = getName<Troot>();
+
   TFile * f = 0;
   TTree * t = 0;
   Troot * b = 0;
 
+  const long long last = update ? lastConvertedEvent<Troot>(outfile, treename) : -1;
+  const bool appending = last >= 0;
+
   int nprocessed = 0;
   for (int i = 0; i < N; i++)
   {
-
     rno_g_file_handle h;
     if (0 == rno_g_init_handle(&h, infiles[i], "r"))
     {
       Traw raw;
       while (ReaderFn(h, &raw) > 0)
       {
+        if (appending && rawEventNumber<Traw>(raw) <= last) continue;
+
+        // Opened only once there is something to write, so that a pass which
+        // finds nothing new leaves the file untouched.
         if (!f)
         {
-          f = new TFile(outfile, "RECREATE");
-          if (!treename) treename = getName<Troot>();
-          t = new TTree(treename, treename);
-          b = new Troot;
-          t->Branch(treename, &b);
+          if (appending)
+          {
+            f = TFile::Open(outfile, "UPDATE");
+            t = f && !f->IsZombie() ? (TTree *) f->Get(treename) : 0;
+            if (!t)
+            {
+              ::Error("mattak::convert", "Could not reopen %s to append to", outfile);
+              delete f;
+              rno_g_close_handle(&h);
+              return 0;
+            }
+            b = new Troot;
+            t->SetBranchAddress(treename, &b);
+          }
+          else
+          {
+            f = new TFile(outfile, "RECREATE");
+            t = new TTree(treename, treename);
+            b = new Troot;
+            t->Branch(treename, &b);
+          }
         }
 
         nprocessed++;
@@ -60,12 +165,16 @@ static int convert_impl(
       }
       rno_g_close_handle(&h);
     }
-
+    else
+    {
+      ::Error("mattak::convert", "Could not open %s", infiles[i]);
+    }
   }
 
   if (f)
   {
-    f->Write();
+    if (appending) t->Write("", TObject::kOverwrite);
+    else f->Write();
     delete f;
     f = 0;
   }
@@ -75,7 +184,7 @@ static int convert_impl(
 
 
 template <typename Traw, int (*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
-static int convert_dir(const char * dir, const char * outfile, const char * treename, int station)
+static int convert_dir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
   std::vector<std::string> files;
   std::vector<const char *> file_ptrs;
@@ -100,73 +209,74 @@ static int convert_dir(const char * dir, const char * outfile, const char * tree
   std::sort(files.begin(), files.end());
 
   file_ptrs.reserve(files.size());
-  for (auto f : files)
+  // by reference: a copy would leave file_ptrs full of dangling pointers
+  for (const auto & f : files)
   {
     file_ptrs.push_back(f.c_str());
   }
 
-  return convert_impl<Traw,ReaderFn,Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename,station);
+  return convert_impl<Traw, ReaderFn, Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename, station, update);
 }
 
 
-int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
+int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename,station);
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename, station, update);
 }
 
-int mattak::convert::convertWaveformFile(const char * infile, const char * outfile, const char * treename,int station)
+int mattak::convert::convertWaveformFile(const char * infile, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename,station);
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename, station, update);
 }
 
-int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename,int station)
+int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename,station);
+  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename, station, update);
 }
 
-int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
+int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename,station);
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename, station, update);
 }
 
-int mattak::convert::convertHeaderFile(const char * infile, const char * outfile, const char * treename,int station)
+int mattak::convert::convertHeaderFile(const char * infile, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename,station);
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename, station, update);
 }
 
-int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename,int station)
+int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename,station);
+  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename, station, update);
 }
 
-int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
+int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename,station);
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename, station, update);
 }
 
-int mattak::convert::convertDAQStatusFile(const char * infile, const char * outfile, const char * treename,int station)
+int mattak::convert::convertDAQStatusFile(const char * infile, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename,station);
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename, station, update);
 }
 
-int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename,int station)
+int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename,station);
+  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename, station, update);
 }
 
-int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
+int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename,station);
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename, station, update);
 }
 
-int mattak::convert::convertPedestalFile(const char * infile, const char * outfile, const char * treename,int station)
+int mattak::convert::convertPedestalFile(const char * infile, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename,station);
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename, station, update);
 }
 
-int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename,int station)
+int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename,station);
+  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename, station, update);
 }
 
 

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -1,8 +1,8 @@
-#include <sys/types.h> 
-#include <dirent.h> 
-#include <sys/stat.h> 
-#include <unistd.h> 
-#include <algorithm> 
+#include <sys/types.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <algorithm>
 #include <vector>
 #include "TTree.h"
 #include "TFile.h"
@@ -16,13 +16,13 @@
 
 
 #ifdef LIBRNO_G_SUPPORT
-#include "rno-g.h" 
+#include "rno-g.h"
 
-template <typename T> const char * getName() { return "unnamed"; } 
-template<> const char * getName<mattak::Waveforms>() { return "waveforms"; } 
-template<> const char * getName<mattak::Header>() { return "header"; } 
-template<> const char * getName<mattak::DAQStatus>() { return "daqstatus"; } 
-template<> const char * getName<mattak::Pedestals>() { return "pedestals"; } 
+template <typename T> const char * getName() { return "unnamed"; }
+template<> const char * getName<mattak::Waveforms>() { return "waveforms"; }
+template<> const char * getName<mattak::Header>() { return "header"; }
+template<> const char * getName<mattak::DAQStatus>() { return "daqstatus"; }
+template<> const char * getName<mattak::Pedestals>() { return "pedestals"; }
 
 
 
@@ -30,47 +30,47 @@ template <typename Traw, int(*ReaderFn)(rno_g_file_handle_t, Traw*), typename Tr
 static int convert_impl(int N, const char ** infiles, const char * outfile, const char * treename, int station)
 
 {
-  TFile * f = 0; 
-  TTree *t = 0; 
-  Troot * b = 0; 
+  TFile * f = 0;
+  TTree *t = 0;
+  Troot * b = 0;
 
-  int nprocessed = 0; 
-  for (int i = 0; i < N; i++) 
+  int nprocessed = 0;
+  for (int i = 0; i < N; i++)
   {
 
-    rno_g_file_handle h; 
-    if (0 == rno_g_init_handle(&h, infiles[i], "r")) 
+    rno_g_file_handle h;
+    if (0 == rno_g_init_handle(&h, infiles[i], "r"))
     {
-      Traw raw; 
-      while (ReaderFn(h, &raw) > 0) 
+      Traw raw;
+      while (ReaderFn(h, &raw) > 0)
       {
-        if (!f) 
+        if (!f)
         {
-          f = new TFile(outfile,"RECREATE"); 
-          if (!treename) treename = getName<Troot>(); 
-          t = new TTree(treename,treename); 
-          b = new Troot; 
-          t->Branch(treename, &b); 
+          f = new TFile(outfile,"RECREATE");
+          if (!treename) treename = getName<Troot>();
+          t = new TTree(treename,treename);
+          b = new Troot;
+          t->Branch(treename, &b);
         }
 
-        nprocessed++; 
-        b = new (b) Troot(&raw); 
-        if (station > 0) b->station_number = station; 
-        t->Fill(); 
+        nprocessed++;
+        b = new (b) Troot(&raw);
+        if (station > 0) b->station_number = station;
+        t->Fill();
       }
-      rno_g_close_handle(&h); 
+      rno_g_close_handle(&h);
     }
 
   }
 
   if (f)
   {
-    f->Write(); 
+    f->Write();
     delete f;
-    f = 0; 
+    f = 0;
   }
 
-  return nprocessed; 
+  return nprocessed;
 }
 
 
@@ -79,119 +79,118 @@ static int convert_impl(int N, const char ** infiles, const char * outfile, cons
 template <typename Traw, int (*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
 static int convert_dir(const char * dir, const char * outfile, const char * treename, int station)
 {
-  std::vector<std::string> files; 
-  std::vector<const char *> file_ptrs; 
-  DIR * dirp = opendir(dir); 
+  std::vector<std::string> files;
+  std::vector<const char *> file_ptrs;
+  DIR * dirp = opendir(dir);
   if (!dirp)
   {
     ::Error("mattak::convert::convert_dir", "Could not open dir %s", dir);
     return 0;
   }
 
-  struct dirent * dent; 
+  struct dirent * dent;
 
 
   while ((dent = readdir(dirp)))
   {
-    std::string fname = dir; 
-    fname+="/"; 
-    fname+=dent->d_name; 
-    files.push_back(fname); 
+    std::string fname = dir;
+    fname+="/";
+    fname+=dent->d_name;
+    files.push_back(fname);
   }
 
-  closedir(dirp); 
-  std::sort(files.begin(), files.end()); 
+  closedir(dirp);
+  std::sort(files.begin(), files.end());
 
-  file_ptrs.reserve(files.size()); 
-  for (auto f : files) 
+  file_ptrs.reserve(files.size());
+  for (auto f : files)
   {
-    file_ptrs.push_back(f.c_str()); 
+    file_ptrs.push_back(f.c_str());
   }
 
-  return convert_impl<Traw,ReaderFn,Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename,station); 
+  return convert_impl<Traw,ReaderFn,Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename,station);
 }
 
 
-int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertWaveformFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertHeaderFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertDAQStatusFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertPedestalFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename,station);
 }
 
 
 #endif
 
-int mattak::convert::makeRunInfo(const char *auxdir, const char * outfile, int station_override, int run_override) 
+int mattak::convert::makeRunInfo(const char *auxdir, const char * outfile, int station_override, int run_override)
 {
-  TFile of(outfile,"RECREATE"); 
-  RunInfo * ri = new RunInfo(auxdir); 
-  if (station_override > 0) 
+  TFile of(outfile,"RECREATE");
+  RunInfo * ri = new RunInfo(auxdir);
+  if (station_override > 0)
   {
-    ri->station = station_override; 
+    ri->station = station_override;
   }
 
-  if (run_override > 0) 
+  if (run_override > 0)
   {
-    ri->run = run_override; 
+    ri->run = run_override;
   }
 
-//  ri->Dump(); 
-  ri->Write("info"); 
+//  ri->Dump();
+  ri->Write("info");
   of.Close();
-  return 0; 
+  return 0;
 }
-

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -78,25 +78,23 @@ static long long lastConvertedEvent(const char * outfile, const char * treename)
   if (t && t->GetEntries() > 0)
   {
     Troot * b = 0;
+    long long first = -1;
     t->SetBranchAddress(treename, &b);
+
+    if (t->GetEntry(0) > 0) first = eventNumberOf<Troot>(b);
     if (t->GetEntry(t->GetEntries() - 1) > 0) last = eventNumberOf<Troot>(b);
 
-    // Event numbers are sequential within a run and start at 0, so a complete
-    // tree holds exactly last+1 entries. If any are missing -- a raw file which
+    // Event numbers are sequential, so a complete tree holds every one of them
+    // between its first and its last. If any are missing -- a raw file which
     // could not be read on an earlier pass, one which turned up only after later
     // events had been converted, or one which was truncated -- then they all sit
     // below `last`, where appending would never reach them again, and only
     // converting from scratch brings them back.
-    //
-    // Counting from 0 assumes the whole run is converted at once, which is what
-    // rno-g-convert-run does (it hands over the entire waveforms/ glob).
-    // Converting only a later subset of a run would look like a gap here and be
-    // rebuilt on every pass: still correct, just not incremental.
-    if (last >= 0 && t->GetEntries() != last + 1)
+    if ((first >= 0 && last >= 0 && t->GetEntries() != last - first + 1) || first > 10)
     {
       ::Error("mattak::convert",
-              "%s holds %lld entries but its last event is %lld, so some are missing; converting from scratch",
-              outfile, (long long) t->GetEntries(), last);
+              "%s holds %lld entries but spans events %lld..%lld, so some are missing; converting from scratch",
+              outfile, (long long) t->GetEntries(), first, last);
       last = -1;
     }
   }

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -1,8 +1,8 @@
-#include <sys/types.h> 
-#include <dirent.h> 
-#include <sys/stat.h> 
-#include <unistd.h> 
-#include <algorithm> 
+#include <sys/types.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <algorithm>
 #include <vector>
 #include "TTree.h"
 #include "TFile.h"
@@ -16,182 +16,178 @@
 
 
 #ifdef LIBRNO_G_SUPPORT
-#include "rno-g.h" 
+#include "rno-g.h"
 
-template <typename T> const char * getName() { return "unnamed"; } 
-template<> const char * getName<mattak::Waveforms>() { return "waveforms"; } 
-template<> const char * getName<mattak::Header>() { return "header"; } 
-template<> const char * getName<mattak::DAQStatus>() { return "daqstatus"; } 
-template<> const char * getName<mattak::Pedestals>() { return "pedestals"; } 
-
+template <typename T> const char * getName() { return "unnamed"; }
+template<> const char * getName<mattak::Waveforms>() { return "waveforms"; }
+template<> const char * getName<mattak::Header>() { return "header"; }
+template<> const char * getName<mattak::DAQStatus>() { return "daqstatus"; }
+template<> const char * getName<mattak::Pedestals>() { return "pedestals"; }
 
 
 template <typename Traw, int(*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
-static int convert_impl(int N, const char ** infiles, const char * outfile, const char * treename, int station)
-
+static int convert_impl(
+    int N, const char ** infiles, const char * outfile,
+    const char * treename, int station)
 {
-  TFile * f = 0; 
-  TTree *t = 0; 
-  Troot * b = 0; 
+  TFile * f = 0;
+  TTree * t = 0;
+  Troot * b = 0;
 
-  int nprocessed = 0; 
-  for (int i = 0; i < N; i++) 
+  int nprocessed = 0;
+  for (int i = 0; i < N; i++)
   {
 
-    rno_g_file_handle h; 
-    if (0 == rno_g_init_handle(&h, infiles[i], "r")) 
+    rno_g_file_handle h;
+    if (0 == rno_g_init_handle(&h, infiles[i], "r"))
     {
-      Traw raw; 
-      while (ReaderFn(h, &raw) > 0) 
+      Traw raw;
+      while (ReaderFn(h, &raw) > 0)
       {
-        if (!f) 
+        if (!f)
         {
-          f = new TFile(outfile,"RECREATE"); 
-          if (!treename) treename = getName<Troot>(); 
-          t = new TTree(treename,treename); 
-          b = new Troot; 
-          t->Branch(treename, &b); 
+          f = new TFile(outfile, "RECREATE");
+          if (!treename) treename = getName<Troot>();
+          t = new TTree(treename, treename);
+          b = new Troot;
+          t->Branch(treename, &b);
         }
 
-        nprocessed++; 
-        b = new (b) Troot(&raw); 
-        if (station > 0) b->station_number = station; 
-        t->Fill(); 
+        nprocessed++;
+        b = new (b) Troot(&raw);
+        if (station > 0) b->station_number = station;
+        t->Fill();
       }
-      rno_g_close_handle(&h); 
+      rno_g_close_handle(&h);
     }
 
   }
 
   if (f)
   {
-    f->Write(); 
+    f->Write();
     delete f;
-    f = 0; 
+    f = 0;
   }
 
-  return nprocessed; 
+  return nprocessed;
 }
-
-
 
 
 template <typename Traw, int (*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
 static int convert_dir(const char * dir, const char * outfile, const char * treename, int station)
 {
-  std::vector<std::string> files; 
-  std::vector<const char *> file_ptrs; 
-  DIR * dirp = opendir(dir); 
+  std::vector<std::string> files;
+  std::vector<const char *> file_ptrs;
+  DIR * dirp = opendir(dir);
   if (!dirp)
   {
     ::Error("mattak::convert::convert_dir", "Could not open dir %s", dir);
     return 0;
   }
 
-  struct dirent * dent; 
-
+  struct dirent * dent;
 
   while ((dent = readdir(dirp)))
   {
-    std::string fname = dir; 
-    fname+="/"; 
-    fname+=dent->d_name; 
-    files.push_back(fname); 
+    std::string fname = dir;
+    fname += "/";
+    fname += dent->d_name;
+    files.push_back(fname);
   }
 
-  closedir(dirp); 
-  std::sort(files.begin(), files.end()); 
+  closedir(dirp);
+  std::sort(files.begin(), files.end());
 
-  file_ptrs.reserve(files.size()); 
-  for (auto f : files) 
+  file_ptrs.reserve(files.size());
+  for (auto f : files)
   {
-    file_ptrs.push_back(f.c_str()); 
+    file_ptrs.push_back(f.c_str());
   }
 
-  return convert_impl<Traw,ReaderFn,Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename,station); 
+  return convert_impl<Traw,ReaderFn,Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename,station);
 }
 
 
-int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertWaveformFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertHeaderFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertDAQStatusFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertPedestalFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename,station);
 }
 
 
 #endif
 
-int mattak::convert::makeRunInfo(const char *auxdir, const char * outfile, int station_override, int run_override) 
+int mattak::convert::makeRunInfo(const char *auxdir, const char * outfile, int station_override, int run_override)
 {
-  TFile of(outfile,"RECREATE"); 
-  RunInfo * ri = new RunInfo(auxdir); 
-  if (station_override > 0) 
+  TFile of(outfile,"RECREATE");
+  RunInfo * ri = new RunInfo(auxdir);
+  if (station_override > 0)
   {
-    ri->station = station_override; 
+    ri->station = station_override;
   }
 
-  if (run_override > 0) 
+  if (run_override > 0)
   {
-    ri->run = run_override; 
+    ri->run = run_override;
   }
 
-//  ri->Dump(); 
-  ri->Write("info"); 
+  //ri->Dump();
+  ri->Write("info");
   of.Close();
-  return 0; 
+  return 0;
 }
-

--- a/src/DAQStatus.cc
+++ b/src/DAQStatus.cc
@@ -2,11 +2,11 @@
 #include "TError.h"
 
 
-ClassImp(mattak::DAQStatus); 
+ClassImp(mattak::DAQStatus);
 
 
-mattak::DAQStatus::DAQStatus(const rno_g_daqstatus_t * status) 
-  : DAQStatus() 
+mattak::DAQStatus::DAQStatus(const rno_g_daqstatus_t * status)
+  : DAQStatus()
 {
 
 #ifndef LIBRNO_G_SUPPORT
@@ -14,20 +14,21 @@ mattak::DAQStatus::DAQStatus(const rno_g_daqstatus_t * status)
   (void) status;
 #else
 
-  this->readout_time_radiant = status->when_radiant; 
-  this->readout_time_lt = status->when_lt; 
+  this->readout_time_radiant = status->when_radiant;
+  this->readout_time_lt = status->when_lt;
+  this->readout_time_didaq = status->when_didaq;
 
-  for (int i = 0; i < mattak::k::num_radiant_channels; i++) 
+  for (int i = 0; i < mattak::k::num_radiant_channels; i++)
   {
-    this->radiant_thresholds[i] = status->radiant_thresholds[i]; 
-    this->radiant_scalers[i] = status->radiant_scalers[i]; 
-    this->radiant_prescalers_m1[i] = status->radiant_prescalers[i]; 
+    this->radiant_thresholds[i] = status->radiant_thresholds[i];
+    this->radiant_scalers[i] = status->radiant_scalers[i];
+    this->radiant_prescalers_m1[i] = status->radiant_prescalers[i];
   }
 
-  this->radiant_scaler_period = status->radiant_scaler_period; 
+  this->radiant_scaler_period = status->radiant_scaler_period;
 
   // For the coincidence trigger
-  for (int i = 0; i < mattak::k::num_lt_channels; i++) 
+  for (int i = 0; i < mattak::k::num_lt_channels; i++)
   {
     this->lt_trigger_thresholds[i] = status->lt_trigger_thresholds[i];
     this->lt_servo_thresholds[i] = status->lt_servo_thresholds[i];
@@ -40,7 +41,7 @@ mattak::DAQStatus::DAQStatus(const rno_g_daqstatus_t * status)
   }
 
   // For the phased-array trigger
-  for (int i = 0; i < mattak::k::num_lt_beams; i++) 
+  for (int i = 0; i < mattak::k::num_lt_beams; i++)
   {
     this->lt_phased_trigger_thresholds[i] = status->lt_phased_trigger_thresholds[i];
     this->lt_phased_servo_thresholds[i] = status->lt_phased_servo_thresholds[i];
@@ -73,19 +74,19 @@ mattak::DAQStatus::DAQStatus(const rno_g_daqstatus_t * status)
   this->lt_100Hz_scalers.trig_phased = status->lt_scalers.s_100Hz.trig_phased;
   this->lt_100Hz_scalers.servo_phased = status->lt_scalers.s_100Hz.servo_phased;
 
-  this->station_number = status->station; 
+  this->station_number = status->station;
 
-  this->radiant_voltages.V10 = status->radiant_voltages.V_1_0; 
-  this->radiant_voltages.V18 = status->radiant_voltages.V_1_8; 
-  this->radiant_voltages.V25 = status->radiant_voltages.V_2_5; 
-  this->radiant_voltages.VLeftMon = status->radiant_voltages.V_LeftMon; 
-  this->radiant_voltages.VRightMon = status->radiant_voltages.V_RightMon; 
+  this->radiant_voltages.V10 = status->radiant_voltages.V_1_0;
+  this->radiant_voltages.V18 = status->radiant_voltages.V_1_8;
+  this->radiant_voltages.V25 = status->radiant_voltages.V_2_5;
+  this->radiant_voltages.VLeftMon = status->radiant_voltages.V_LeftMon;
+  this->radiant_voltages.VRightMon = status->radiant_voltages.V_RightMon;
 
-  this->calinfo.enabled = status->cal.enabled; 
-  this->calinfo.T = status->cal.T_times_16/16.; 
+  this->calinfo.enabled = status->cal.enabled;
+  this->calinfo.T = status->cal.T_times_16/16.;
   this->calinfo.mode = (mattak::CalpulserMode) status->cal.mode;
   this->calinfo.output =(mattak::CalpulserOutput)  status->cal.out;
-  this->calinfo.attenuation = status->cal.atten_times_2/2.; 
+  this->calinfo.attenuation = status->cal.atten_times_2/2.;
 
 
 #endif

--- a/src/DAQStatus.cc
+++ b/src/DAQStatus.cc
@@ -88,6 +88,34 @@ mattak::DAQStatus::DAQStatus(const rno_g_daqstatus_t * status)
   this->calinfo.output =(mattak::CalpulserOutput)  status->cal.out;
   this->calinfo.attenuation = status->cal.atten_times_2/2.;
 
+  // DIDAQ, when present, is a drop-in replacement for RADIANT+FLOWER
+  for (int i = 0; i < mattak::k::num_radiant_channels; i++)
+  {
+    this->didaq_coin_thresholds[i] = status->didaq_coin_thresholds[i];
+    this->didaq_scalers.coinc_singles_1Hz[i] = status->didaq_scalers.coinc_singles_1Hz[i];
+    this->didaq_scalers.coinc_singles_1Hz_gated[i] = status->didaq_scalers.coinc_singles_1Hz_gated[i];
+  }
+
+  for (int i = 0; i < mattak::k::num_didaq_coinc; i++)
+  {
+    this->didaq_scalers.coinc_trig_100mHz[i] = status->didaq_scalers.coinc_trig_100mHz[i];
+    this->didaq_scalers.coinc_trig_100mHz_gated[i] = status->didaq_scalers.coinc_trig_100mHz_gated[i];
+  }
+
+  for (int i = 0; i < mattak::k::num_didaq_beams; i++)
+  {
+    this->didaq_phased_trigger_thresholds[i] = status->didaq_phased_trigger_thresholds[i];
+    this->didaq_phased_servo_thresholds[i] = status->didaq_phased_servo_thresholds[i];
+    this->didaq_scalers.beam_trig_100mHz[i] = status->didaq_scalers.beam_trig_100mHz[i];
+    this->didaq_scalers.beam_trig_100mHz_gated[i] = status->didaq_scalers.beam_trig_100mHz_gated[i];
+    this->didaq_scalers.beam_servo_1Hz[i] = status->didaq_scalers.beam_servo_1Hz[i];
+  }
+
+  this->didaq_scalers.total_beam_100mHz = status->didaq_scalers.total_beam_100mHz;
+  this->didaq_scalers.total_beam_100mHz_gated = status->didaq_scalers.total_beam_100mHz_gated;
+  this->didaq_scalers.total_beam_1Hz = status->didaq_scalers.total_beam_1Hz;
+  this->didaq_scalers.num_pps = status->didaq_scalers.num_pps;
+  this->didaq_scalers.clk_rate = status->didaq_scalers.clk_rate;
 
 #endif
 

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -589,8 +589,9 @@ static void findIncompleteEntry(mattak::Dataset::tree_field<T> * field, mattak::
 }
 
 
-float mattak::Dataset::radiantSampleRate(bool force)
+float mattak::Dataset::sampleRate(bool force)
 {
+  // While this function returns "radiant_sample_rate" it is not radiant specific (check header doc-string)
   if (wf_meta.ptr == nullptr) {
     return (info() && info()->radiant_sample_rate) ? info()->radiant_sample_rate : 3200;
   }

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -52,7 +52,7 @@ static void clear(mattak::Dataset::file_field<D> * field)
 #define BITBUCKET "/dev/null"
 #endif
 
-void mattak::Dataset::setupRadiantMeta()
+void mattak::Dataset::setupDigitizerMeta()
 {
 
   // HACK: separately make the sample rate from the waveform file
@@ -62,13 +62,13 @@ void mattak::Dataset::setupRadiantMeta()
   wf_meta.file = TFile::Open(wf.file->GetName());
   if (!wf_meta.file)
   {
-    ::Warning("mattak::Dataset::setupRadiantMeta", "Could not reopen %s", wf.file->GetName());
+    ::Warning("mattak::Dataset::setupDigitizerMeta", "Could not reopen %s", wf.file->GetName());
     return;
   }
   wf_meta.tree = (TTree*) wf_meta.file->Get(wf.tree->GetName());
   if (!wf_meta.tree)
   {
-    ::Warning("mattak::Dataset::setupRadiantMeta", "Could not find tree %s in %s", wf.tree->GetName(), wf.file->GetName());
+    ::Warning("mattak::Dataset::setupDigitizerMeta", "Could not find tree %s in %s", wf.tree->GetName(), wf.file->GetName());
     clear(&wf_meta);
     return;
   }
@@ -79,6 +79,32 @@ void mattak::Dataset::setupRadiantMeta()
   UInt_t found = 0;
   wf_meta.tree->SetBranchStatus("*radiant_sampling_rate",1, &found);
   wf_meta.tree->SetBranchStatus("*digitizer_readout_delay_ns*",1, &found);
+  wf_meta.tree->SetBranchStatus("*bytes_per_sample*",1, &found);
+
+  // peek at the first event's metadata (no waveform samples are read, since
+  // those branches are disabled above) to figure out which digitizer wrote this run
+  if (wf_meta.tree->GetEntries() > 0)
+  {
+    wf_meta.tree->GetEntry(0);
+    setDigitizer(wf_meta.ptr->bytes_per_sample);
+  }
+}
+
+void mattak::Dataset::setDigitizer(uint8_t bytes_per_sample)
+{
+  switch (bytes_per_sample)
+  {
+    case 0:
+    case 2:
+      digitizer_type = digitizer::RADIANT;
+      break;
+    case 1:
+      digitizer_type = digitizer::DIDAQ;
+      break;
+    default:
+      digitizer_type = digitizer::Unknown;
+      break;
+  }
 }
 
 /** Silently check if file exists, supporting all protocols ROOT does */
@@ -330,7 +356,7 @@ int mattak::Dataset::loadCombinedFile(const char * f)
     return -1;
   }
 
-  setupRadiantMeta();
+  setupDigitizerMeta();
 
   if (opt.verbose) ::Info("mattak::Dataset::loadCombinedFile", "Found waveforms and headers in %s", f);
 
@@ -409,7 +435,7 @@ int mattak::Dataset::loadDir(const char * dir)
     }
   }
 
-  setupRadiantMeta();
+  setupDigitizerMeta();
 
   //now load the header files
   if (opt.verbose) ::Info("mattak::Dataset::loadDir", "About to load headers");
@@ -439,18 +465,26 @@ int mattak::Dataset::loadDir(const char * dir)
 
   if (full_dataset)
   {
-    ds.tree->BuildIndex("int(readout_time_radiant)", "1e9*(readout_time_radiant-int(readout_time_radiant))");
+    if (digitizer_type == digitizer::RADIANT)
+      ds.tree->BuildIndex("int(readout_time_radiant)", "1e9*(readout_time_radiant-int(readout_time_radiant))");
+    else if (digitizer_type == digitizer::DIDAQ)
+      ds.tree->BuildIndex("int(readout_time_didaq)", "1e9*(readout_time_didaq-int(readout_time_didaq))");
+    else
+      ::Error("mattak::Dataset::loadDir", "Unkown digitizer type.");
   }
 
-  //and the pedestal files
-  if (opt.verbose) ::Info("mattak::Dataset::loadDir", "About to load pedestal");
-  if (setup(&pd, Form("%s/pedestal.root", dir), pedestal_tree_names, nullptr, opt.verbose))
+  if (digitizer_type == digitizer::RADIANT)
   {
-    ::Warning("mattak::Dataset::loadDir", "Failed to find pedestal.root in %s (this is usually ok if you don't need them)", dir);
-  }
-  else
-  {
-    if (opt.verbose) ::Info("mattak::Dataset::loadDir", " ... success");
+    //and the pedestal files
+    if (opt.verbose) ::Info("mattak::Dataset::loadDir", "About to load pedestal");
+    if (setup(&pd, Form("%s/pedestal.root", dir), pedestal_tree_names, nullptr, opt.verbose))
+    {
+      ::Warning("mattak::Dataset::loadDir", "Failed to find pedestal.root in %s (this is usually ok if you don't need them)", dir);
+    }
+    else
+    {
+      if (opt.verbose) ::Info("mattak::Dataset::loadDir", " ... success");
+    }
   }
 
   //and try the runinfo file

--- a/src/Header.cc
+++ b/src/Header.cc
@@ -37,46 +37,92 @@ mattak::Header::Header(const rno_g_header_t * head)
 
   this->trigger_info.force_trigger = !!(head->trigger_type & RNO_G_TRIGGER_SOFT);
   this->trigger_info.pps_trigger = !!(head->trigger_type & RNO_G_TRIGGER_PPS);
-  this->trigger_info.rf_trigger = ! (this->trigger_info.force_trigger || this->trigger_info.pps_trigger);
-  this->trigger_info.radiant_trigger = !!(head->trigger_type & (RNO_G_TRIGGER_RF_RADIANTX));
-  this->trigger_info.lt_trigger = !!(head->trigger_type & (RNO_G_TRIGGER_RF_LT_SIMPLE | RNO_G_TRIGGER_RF_LT_PHASED));
-  if (this->trigger_info.radiant_trigger)
+  this->trigger_info.rf_trigger = !(this->trigger_info.force_trigger || this->trigger_info.pps_trigger);
+
+  // The DIDAQ bit is the top (last) bit of the now 16-bit trigger_type. When set, the low
+  // bits are DIDAQ's own trigger sources, which reuse some RADIANT/FLOWER bit positions for an
+  // unrelated meaning (e.g. bit 2 is RF_LT_SIMPLE on RADIANT/FLOWER but RF_DIDAQ_COINC0 on DIDAQ),
+  // so they must not be interpreted with the RADIANT/FLOWER logic below.
+  bool is_didaq = head->trigger_type & RNO_G_TRIGGER_DIDAQ;
+
+  if (!is_didaq)
   {
-    this->trigger_info.which_radiant_trigger =
-      (head->trigger_type & RNO_G_TRIGGER_RF_RADIANT0) ? 0 :
-      (head->trigger_type & RNO_G_TRIGGER_RF_RADIANT1) ? 1 :
-      -1;
-  }
-  else this->trigger_info.which_radiant_trigger=-128;
+    this->trigger_info.radiant_trigger = !!(head->trigger_type & (RNO_G_TRIGGER_RF_RADIANTX));
+    this->trigger_info.lt_trigger = !!(head->trigger_type & (RNO_G_TRIGGER_RF_LT_SIMPLE | RNO_G_TRIGGER_RF_LT_PHASED));
+    this->trigger_info.didaq_trigger = false;
+    if (this->trigger_info.radiant_trigger)
+    {
+      this->trigger_info.which_radiant_trigger =
+        (head->trigger_type & RNO_G_TRIGGER_RF_RADIANT0) ? 0 :
+        (head->trigger_type & RNO_G_TRIGGER_RF_RADIANT1) ? 1 :
+        -1;
+    }
+    else this->trigger_info.which_radiant_trigger=-128;
 
-  if (this->trigger_info.lt_trigger)
+    if (this->trigger_info.lt_trigger)
+    {
+      this->trigger_info.which_lt_trigger =
+        (head->trigger_type & RNO_G_TRIGGER_RF_LT_SIMPLE) ? 0 :
+        (head->trigger_type & RNO_G_TRIGGER_RF_LT_PHASED) ? 1 :
+        -1;
+    }
+    else this->trigger_info.which_lt_trigger = -1;
+
+    for (int i = 0 ; i < RNO_G_NUM_RADIANT_CHANNELS; i++)
+    {
+      this->trigger_info.radiant_info.start_windows[i][0] = head->radiant_start_windows[i][0];
+      this->trigger_info.radiant_info.start_windows[i][1] = head->radiant_start_windows[i][1];
+    }
+
+    for (int i = 0; i  < 2; i++)
+    {
+      this->trigger_info.radiant_info.RF_masks[i] = head->radiant_trigger_cfg[i].mask;
+      this->trigger_info.radiant_info.RF_ncoinc[i] = head->radiant_trigger_cfg[i].ncoinc;
+      this->trigger_info.radiant_info.RF_window[i] = head->radiant_trigger_cfg[i].window;
+    }
+
+    this->trigger_info.lt_info.window = head->lt_simple_trigger_cfg.window;
+    this->trigger_info.lt_info.num_coinc = head->lt_simple_trigger_cfg.num_coinc;
+    this->trigger_info.lt_info.vppmode = head->lt_simple_trigger_cfg.vpp_mode;
+    this->trigger_info.lt_info.channel_mask = head->lt_simple_trigger_cfg.channel_mask;
+    this->trigger_info.lt_info.beam_mask = head->lt_phased_trigger_cfg.beam_mask;
+
+  }
+  else
   {
-    this->trigger_info.which_lt_trigger =
-      (head->trigger_type & RNO_G_TRIGGER_RF_LT_SIMPLE) ? 0 :
-      (head->trigger_type & RNO_G_TRIGGER_RF_LT_PHASED) ? 1 :
-      -1;
+    // No RADIANT/FLOWER boards on DIDAQ, so radiant_trigger/lt_trigger don't apply.
+    this->trigger_info.radiant_trigger = false;
+    this->trigger_info.lt_trigger = false;
+
+    this->trigger_info.didaq_info.type = head->trigger_type;
+
+    // RNO_G_TRIGGER_RF_DIDAQ_* are (RNO_G_TRIGGER_DIDAQ | some-bit) combinations, and we already
+    // know the DIDAQ bit is set here -- so testing `trigger_type & RNO_G_TRIGGER_RF_DIDAQ_X` with
+    // a plain truthiness check would always be true (satisfied by the shared DIDAQ bit alone),
+    // regardless of whether bit X itself is set. Compare against the whole combined constant with
+    // `==` instead, so both the DIDAQ bit and the specific source bit are required.
+    bool didaq_coinc0 = (head->trigger_type & RNO_G_TRIGGER_RF_DIDAQ_COINC0) == RNO_G_TRIGGER_RF_DIDAQ_COINC0;
+    bool didaq_coinc1 = (head->trigger_type & RNO_G_TRIGGER_RF_DIDAQ_COINC1) == RNO_G_TRIGGER_RF_DIDAQ_COINC1;
+    bool didaq_surf_up = (head->trigger_type & RNO_G_TRIGGER_RF_DIDAQ_SURF_UP) == RNO_G_TRIGGER_RF_DIDAQ_SURF_UP;
+    bool didaq_surf_down = (head->trigger_type & RNO_G_TRIGGER_RF_DIDAQ_SURF_DOWN) == RNO_G_TRIGGER_RF_DIDAQ_SURF_DOWN;
+    bool didaq_deep_phased = (head->trigger_type & RNO_G_TRIGGER_RF_DIDAQ_DEEP_PHASED) == RNO_G_TRIGGER_RF_DIDAQ_DEEP_PHASED;
+
+    this->trigger_info.didaq_trigger = didaq_coinc0 || didaq_coinc1 || didaq_surf_up || didaq_surf_down || didaq_deep_phased;
+
+    // trigger_mask: "Which channels (or beams?) caused the trigger" -- DIDAQ has no separate
+    // channel-mask/beam-mask config fields of its own, so use the per-event trigger_mask for both,
+    // filed under whichever of the two DEEP_PHASED (beam-like) vs. everything else (channel-like) applies.
+    if (didaq_deep_phased)
+      this->trigger_info.didaq_info.beam_mask = head->trigger_mask;
+    else if (this->trigger_info.didaq_trigger)
+      this->trigger_info.didaq_info.channel_mask = head->trigger_mask;
+
+    // `didaq_start_offsets` is the union alternative to `radiant_start_windows` (see comment above).
+    for (int i = 0 ; i < RNO_G_NUM_RADIANT_CHANNELS; i++)
+    {
+      this->trigger_info.didaq_info.start_offsets[i] = head->didaq_start_offsets[i];
+    }
   }
-  else this->trigger_info.which_lt_trigger = -1;
-
-  for (int i = 0 ; i < RNO_G_NUM_RADIANT_CHANNELS; i++)
-  {
-    this->trigger_info.radiant_info.start_windows[i][0] = head->radiant_start_windows[i][0];
-    this->trigger_info.radiant_info.start_windows[i][1] = head->radiant_start_windows[i][1];
-  }
-
-  for (int i = 0; i  < 2; i++)
-  {
-    this->trigger_info.radiant_info.RF_masks[i] = head->radiant_trigger_cfg[i].mask;
-    this->trigger_info.radiant_info.RF_ncoinc[i] = head->radiant_trigger_cfg[i].ncoinc;
-    this->trigger_info.radiant_info.RF_window[i] = head->radiant_trigger_cfg[i].window;
-  }
-
-  this->trigger_info.lt_info.window = head->lt_simple_trigger_cfg.window;
-  this->trigger_info.lt_info.num_coinc = head->lt_simple_trigger_cfg.num_coinc;
-  this->trigger_info.lt_info.vppmode = head->lt_simple_trigger_cfg.vpp_mode;
-  this->trigger_info.lt_info.channel_mask=head->lt_simple_trigger_cfg.channel_mask;
-  this->trigger_info.lt_info.beam_mask=head->lt_phased_trigger_cfg.beam_mask;
-
 #else
   ::Error("mattak::Header::Header", "Not compiled with librno-g support");
   (void) head;

--- a/src/Header.cc
+++ b/src/Header.cc
@@ -16,7 +16,6 @@ mattak::Header::Header(const rno_g_header_t * head)
   this->event_number = head->event_number;
   this->trigger_number = head->trigger_number;
   this->station_number = head->station_number;
-  this->buffer_length = head->radiant_nsamples;
   this->pretrigger_samples= head->pretrigger_windows*128;
   this->readout_time = head->readout_time_secs + 1e-9 * head->readout_time_nsecs;
   this->pps_num = head->pps_count;
@@ -77,9 +76,6 @@ mattak::Header::Header(const rno_g_header_t * head)
   this->trigger_info.lt_info.vppmode = head->lt_simple_trigger_cfg.vpp_mode;
   this->trigger_info.lt_info.channel_mask=head->lt_simple_trigger_cfg.channel_mask;
   this->trigger_info.lt_info.beam_mask=head->lt_phased_trigger_cfg.beam_mask;
-
-
-
 
 #else
   ::Error("mattak::Header::Header", "Not compiled with librno-g support");

--- a/src/LinkDef.h
+++ b/src/LinkDef.h
@@ -38,6 +38,7 @@
 #pragma link C++ class mattak::GNSS::Sat+;
 #pragma link C++ class mattak::DAQStatus+;
 #pragma link C++ class mattak::LTScalerGroup+;
+#pragma link C++ class mattak::DidaqScalers+;
 #pragma link C++ class mattak::CalpulserInfo+;
 #pragma link C++ class mattak::RadiantVoltages+;
 #pragma link C++ enum mattak::CalpulserOutput;

--- a/src/LinkDef.h
+++ b/src/LinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class mattak::TriggerInfo+;
 #pragma link C++ class mattak::RadiantTriggerInfo+;
 #pragma link C++ class mattak::LTTriggerInfo+;
+#pragma link C++ class mattak::DidaqTriggerInfo+;
 #pragma link C++ class mattak::Sensors+;
 #pragma link C++ class mattak::LTEStats+;
 #pragma link C++ class mattak::GNSS+;

--- a/src/TriggerInfo.cc
+++ b/src/TriggerInfo.cc
@@ -1,7 +1,7 @@
-#include "mattak/TriggerInfo.h" 
+#include "mattak/TriggerInfo.h"
 
 
-ClassImp(mattak::TriggerInfo); 
-ClassImp(mattak::RadiantTriggerInfo); 
-ClassImp(mattak::LTTriggerInfo); 
-
+ClassImp(mattak::TriggerInfo);
+ClassImp(mattak::RadiantTriggerInfo);
+ClassImp(mattak::LTTriggerInfo);
+ClassImp(mattak::DidaqTriggerInfo);

--- a/src/Waveforms.cc
+++ b/src/Waveforms.cc
@@ -34,7 +34,7 @@ mattak::Waveforms::Waveforms(const rno_g_waveform_t * wf )
     if(wf->digitizer_readout_delay[i]!=0) this->digitizer_readout_delay_ns[i]=float(wf->digitizer_readout_delay[i])*128./float(wf->sampling_rate)*1000;
 
     if (this->bytes_per_sample == 1)
-      memcpy(this->didaq_data[i], wf->didaq_waveforms[i], sizeof(uint8_t) * mattak::k::num_didaq_samples);
+      memcpy(this->didaq_data[i], wf->didaq_waveforms[i], sizeof(uint8_t) * wf->nsamples);
     else
       memcpy(this->radiant_data[i], wf->radiant_waveforms[i], sizeof(int16_t) * mattak::k::num_radiant_samples);
   }

--- a/src/Waveforms.cc
+++ b/src/Waveforms.cc
@@ -7,6 +7,7 @@
 #include "TPaveText.h"
 #include "TError.h"
 
+#include <math.h>       /* ceil */
 
 ClassImp(mattak::Waveforms);
 ClassImp(mattak::IWaveforms);
@@ -99,7 +100,7 @@ static TVirtualPad * drawImpl(const T & wf, const mattak::WaveformPlotOptions & 
   int nplots = __builtin_popcount(opt.mask);
   if (!nplots) return nullptr;
 
-  bool use_same = opt.same && where; 
+  bool use_same = opt.same && where;
   if (!where )
   {
     where = new TCanvas(Form("c_s%d_r%d_ev%d", wf.station_number, wf.run_number, wf.event_number), Form("Station %d, Run %d, Event %d", wf.station_number, wf.run_number, wf.event_number), opt.width, opt.height);
@@ -118,13 +119,13 @@ static TVirtualPad * drawImpl(const T & wf, const mattak::WaveformPlotOptions & 
   {
 
     where->Clear();
-    nrows =opt.rows ?:
+    nrows = opt.rows ?:
                 nplots < 4 ? 1:
                 nplots < 9 ? 2:
                 nplots < 12? 3:
                 4;
 
-    ncols = ceil (nplots / (float(nrows)));
+    ncols = ceil(nplots / (float(nrows)));
 
     if (!opt.share_xaxis && !opt.share_yaxis)
     {

--- a/src/Waveforms.cc
+++ b/src/Waveforms.cc
@@ -24,14 +24,19 @@ mattak::Waveforms::Waveforms(const rno_g_waveform_t * wf )
 #else
   this->run_number = wf->run_number;
   this->event_number = wf->event_number;
-  this->buffer_length = wf->radiant_nsamples;
+  this->buffer_length = wf->nsamples;
   this->station_number = wf->station;
-  this->radiant_sampling_rate = wf->radiant_sampling_rate;
+  this->radiant_sampling_rate = wf->sampling_rate;
+  this->bytes_per_sample = wf->bytes_per_sample ? wf->bytes_per_sample : 2; // 0 means RADIANT (2 B/sample) for writers predating this field
 
   for (unsigned i = 0; i < mattak::k::num_radiant_channels; i++)
   {
-    if(wf->digitizer_readout_delay[i]!=0) this->digitizer_readout_delay_ns[i]=float(wf->digitizer_readout_delay[i])*128./float(wf->radiant_sampling_rate)*1000;
-    memcpy(this->radiant_data[i], wf->radiant_waveforms[i], sizeof(int16_t) * mattak::k::num_radiant_samples);
+    if(wf->digitizer_readout_delay[i]!=0) this->digitizer_readout_delay_ns[i]=float(wf->digitizer_readout_delay[i])*128./float(wf->sampling_rate)*1000;
+
+    if (this->bytes_per_sample == 1)
+      memcpy(this->didaq_data[i], wf->didaq_waveforms[i], sizeof(uint8_t) * mattak::k::num_didaq_samples);
+    else
+      memcpy(this->radiant_data[i], wf->radiant_waveforms[i], sizeof(int16_t) * mattak::k::num_radiant_samples);
   }
 
 #endif
@@ -44,11 +49,19 @@ mattak::CalibratedWaveforms::CalibratedWaveforms(const Waveforms & wf, const Hea
   event_number = wf.event_number;
   station_number = wf.station_number;
   buffer_length = wf.buffer_length;
+  bytes_per_sample = wf.bytes_per_sample;
 
   if (hdr.run_number != wf.run_number && hdr.event_number != wf.run_number && hdr.station_number != wf.station_number)
   {
     ::Warning("mattak::CalibratedWaveforms::CalibratedWaveforms", "Possible event-header mismatch (waveform run %d event %d, header run %d event %d)",
               (int) wf.run_number, (int) wf.event_number, (int) hdr.run_number, (int) hdr.event_number);
+  }
+
+  if (wf.bytes_per_sample == 1)
+  {
+    ::Warning("mattak::CalibratedWaveforms::CalibratedWaveforms", "Voltage calibration of DIDAQ (8-bit) waveforms is not yet supported (station %d, run %d, event %d); calibrated data will be zero.",
+              (int) wf.station_number, (int) wf.run_number, (int) wf.event_number);
+    return;
   }
 
   for (int ch = 0; ch < mattak::k::num_radiant_channels; ch++)
@@ -66,6 +79,15 @@ const char * getYaxisLabel<mattak::Waveforms> () { return "amplitude [adu]"; }
 template<>
 const char * getYaxisLabel<mattak::CalibratedWaveforms> () { return "amplitude [V]"; }
 
+// mattak::Waveforms may hold either RADIANT (radiant_data) or DIDAQ (didaq_data) samples, picked by bytes_per_sample.
+template <typename T>
+static inline double getSample(const T & wf, int chan, int isamp) { return wf.radiant_data[chan][isamp]; }
+
+template <>
+inline double getSample<mattak::Waveforms>(const mattak::Waveforms & wf, int chan, int isamp)
+{
+  return wf.bytes_per_sample == 1 ? wf.didaq_data[chan][isamp] : wf.radiant_data[chan][isamp];
+}
 
 template <typename T>
 TGraph* graphImpl(const T & wf, int chan, bool ns)
@@ -79,7 +101,7 @@ TGraph* graphImpl(const T & wf, int chan, bool ns)
   {
     double x = ns ? isamp/rate : isamp;
     g->GetX()[isamp] = x;
-    g->GetY()[isamp] = wf.radiant_data[chan][isamp];
+    g->GetY()[isamp] = getSample(wf, chan, isamp);
   }
 
 
@@ -177,11 +199,9 @@ static TVirtualPad * drawImpl(const T & wf, const mattak::WaveformPlotOptions & 
       if ( (1 <<ichan) & ~opt.mask) continue;
       for (int isamp = 0; isamp < wf.buffer_length; isamp++)
       {
-        if (wf.radiant_data[ichan][isamp] > gmax)
-          gmax = wf.radiant_data[ichan][isamp];
-
-        if (wf.radiant_data[ichan][isamp] < gmin)
-          gmin = wf.radiant_data[ichan][isamp];
+        double sample = getSample(wf, ichan, isamp);
+        if (sample > gmax) gmax = sample;
+        if (sample < gmin) gmin = sample;
       }
     }
   }

--- a/src/mattak/Constants.h
+++ b/src/mattak/Constants.h
@@ -13,8 +13,10 @@ namespace mattak
     constexpr uint16_t num_radiant_samples = 2048;
     constexpr uint16_t num_didaq_samples = 4096; // must match RNO_G_MAX_DIDAQ_NSAMPLES in rno-g.h
     constexpr uint16_t num_lab4_samples = 4096;
-    constexpr uint16_t num_lt_channels = 4; 
+    constexpr uint16_t num_lt_channels = 4;
     constexpr uint16_t num_lt_beams = 12;
+    constexpr uint16_t num_didaq_coinc = 2; // must match RNO_G_NUM_DIDAQ_COINC in rno-g.h
+    constexpr uint16_t num_didaq_beams = 10; // must match RNO_G_NUM_DIDAQ_BEAMS in rno-g.h
     constexpr uint16_t radiant_window_size = 128; 
     constexpr uint16_t radiant_windows_per_buffer = num_radiant_samples / radiant_window_size; 
   }

--- a/src/mattak/Constants.h
+++ b/src/mattak/Constants.h
@@ -9,9 +9,10 @@ namespace mattak
 {
   namespace k
   {
-    constexpr uint8_t num_radiant_channels = 24; 
-    constexpr uint16_t num_radiant_samples = 2048; 
-    constexpr uint16_t num_lab4_samples = 4096; 
+    constexpr uint8_t num_radiant_channels = 24;
+    constexpr uint16_t num_radiant_samples = 2048;
+    constexpr uint16_t num_didaq_samples = 4096; // must match RNO_G_MAX_DIDAQ_NSAMPLES in rno-g.h
+    constexpr uint16_t num_lab4_samples = 4096;
     constexpr uint16_t num_lt_channels = 4; 
     constexpr uint16_t num_lt_beams = 12;
     constexpr uint16_t radiant_window_size = 128; 

--- a/src/mattak/Converter.h
+++ b/src/mattak/Converter.h
@@ -7,24 +7,37 @@ namespace mattak
   {
 #ifdef LIBRNO_G_SUPPORT
 
-    int convertWaveformFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertWaveformDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    /* All of these take an `update` flag. With it set, an output file which
+     * already exists is extended with whatever input files are not in it yet,
+     * instead of being written from scratch. That is what makes converting a
+     * run which is still being taken cheap, since each pass then only pays for
+     * the raw files which arrived since the last one.
+     *
+     * Which input files an output file holds is recorded inside it, so this is
+     * safe to repeat: files already converted are skipped, and anything the
+     * record does not explain (an input file which changed, one which appeared
+     * before a file already converted, a mismatched entry count, an output file
+     * which cannot be opened) falls back to converting from scratch.
+     */
 
-    int convertHeaderFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertHeaderDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertWaveformFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertWaveformDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
 
-    int convertDAQStatusFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertDAQStatusDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertHeaderFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertHeaderDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
 
-    int convertPedestalFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertPedestalDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertDAQStatusFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertDAQStatusDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+
+    int convertPedestalFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertPedestalDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
 
 #endif
-    int makeRunInfo(const char * auxdir, const char * outfile, int station_override = -1, int run_override =-1); 
+    int makeRunInfo(const char * auxdir, const char * outfile, int station_override = -1, int run_override =-1);
   }
 }
 

--- a/src/mattak/Converter.h
+++ b/src/mattak/Converter.h
@@ -7,24 +7,24 @@ namespace mattak
   {
 #ifdef LIBRNO_G_SUPPORT
 
-    int convertWaveformFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertWaveformDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertWaveformFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1);
+    int convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1);
+    int convertWaveformDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1);
 
-    int convertHeaderFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertHeaderDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertHeaderFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1);
+    int convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1);
+    int convertHeaderDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1);
 
-    int convertDAQStatusFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertDAQStatusDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertDAQStatusFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1);
+    int convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1);
+    int convertDAQStatusDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1);
 
-    int convertPedestalFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertPedestalDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertPedestalFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1);
+    int convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1);
+    int convertPedestalDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1);
 
 #endif
-    int makeRunInfo(const char * auxdir, const char * outfile, int station_override = -1, int run_override =-1); 
+    int makeRunInfo(const char * auxdir, const char * outfile, int station_override = -1, int run_override =-1);
   }
 }
 

--- a/src/mattak/DAQStatus.h
+++ b/src/mattak/DAQStatus.h
@@ -12,6 +12,11 @@
 
 #include "mattak/Constants.h"
 
+#ifdef LIBRNO_G_SUPPORT
+static_assert(mattak::k::num_didaq_coinc == RNO_G_NUM_DIDAQ_COINC, "mattak::k::num_didaq_coinc out of sync with librno-g");
+static_assert(mattak::k::num_didaq_beams == RNO_G_NUM_DIDAQ_BEAMS, "mattak::k::num_didaq_beams out of sync with librno-g");
+#endif
+
 
 namespace mattak
 {
@@ -29,6 +34,22 @@ namespace mattak
     uint16_t trig_per_beam[mattak::k::num_lt_beams] = {0};
     uint16_t servo_phased = 0;
     uint16_t servo_per_beam[mattak::k::num_lt_beams] = {0};
+  };
+
+  struct DidaqScalers
+  {
+    uint16_t coinc_singles_1Hz[mattak::k::num_radiant_channels] = {0};
+    uint16_t coinc_singles_1Hz_gated[mattak::k::num_radiant_channels] = {0};
+    uint16_t coinc_trig_100mHz[mattak::k::num_didaq_coinc] = {0};
+    uint16_t coinc_trig_100mHz_gated[mattak::k::num_didaq_coinc] = {0};
+    uint16_t beam_trig_100mHz[mattak::k::num_didaq_beams] = {0};
+    uint16_t beam_trig_100mHz_gated[mattak::k::num_didaq_beams] = {0};
+    uint16_t beam_servo_1Hz[mattak::k::num_didaq_beams] = {0};
+    uint16_t total_beam_100mHz = 0;
+    uint16_t total_beam_100mHz_gated = 0;
+    uint16_t total_beam_1Hz = 0;
+    uint16_t num_pps = 0;
+    uint32_t clk_rate = 0;
   };
 
   struct RadiantVoltages
@@ -96,6 +117,12 @@ namespace mattak
 
       RadiantVoltages radiant_voltages;
       CalpulserInfo calinfo;
+
+      // DIDAQ, when present, is a drop-in replacement for RADIANT+FLOWER; see rno_g_daqstatus_t in rno-g.h
+      uint8_t didaq_coin_thresholds[mattak::k::num_radiant_channels] = {0};
+      uint16_t didaq_phased_trigger_thresholds[mattak::k::num_didaq_beams] = {0};
+      uint16_t didaq_phased_servo_thresholds[mattak::k::num_didaq_beams] = {0};
+      DidaqScalers didaq_scalers;
 
     ClassDef(DAQStatus, 7);
   };

--- a/src/mattak/DAQStatus.h
+++ b/src/mattak/DAQStatus.h
@@ -73,6 +73,7 @@ namespace mattak
 
       double readout_time_radiant = 0;
       double readout_time_lt = 0;
+      double readout_time_didaq = 0;
 
       uint32_t radiant_thresholds[mattak::k::num_radiant_channels] = {0};
       uint32_t radiant_scalers[mattak::k::num_radiant_channels] = {0};
@@ -96,7 +97,7 @@ namespace mattak
       RadiantVoltages radiant_voltages;
       CalpulserInfo calinfo;
 
-    ClassDef(DAQStatus, 6);
+    ClassDef(DAQStatus, 7);
   };
 
 }

--- a/src/mattak/Dataset.h
+++ b/src/mattak/Dataset.h
@@ -62,6 +62,13 @@ namespace mattak
   {
 
     public:
+      enum class digitizer
+      {
+        Unknown,
+        RADIANT,
+        DIDAQ
+      };
+
       Dataset(int station, int run, const DatasetOptions & opt = DatasetOptions());
       Dataset(const DatasetOptions & opt = DatasetOptions());
 
@@ -125,6 +132,7 @@ namespace mattak
       TTree * wfTree() { return wf.tree; }
 
       bool isFullDataset() const { return full_dataset; }
+      digitizer getDigitizer() const { return digitizer_type; }
       void setCalibration(const VoltageCalibration * calib);
       const VoltageCalibration * getCalibration() const { return opt.calib; }
 
@@ -164,7 +172,8 @@ namespace mattak
       tree_field<Pedestals> pd;
       file_field<RunInfo> runinfo;
 
-      void setupRadiantMeta();
+      void setupDigitizerMeta();
+      void setDigitizer(uint8_t bytes_per_sample);
 
       field<CalibratedWaveforms> calib_wf;
 
@@ -173,6 +182,7 @@ namespace mattak
 
 
       bool full_dataset = false;
+      digitizer digitizer_type = digitizer::Unknown;
       DatasetOptions opt;
 
   };

--- a/src/mattak/Dataset.h
+++ b/src/mattak/Dataset.h
@@ -118,7 +118,7 @@ namespace mattak
 
       // these methods are useful if you want to read waveform metadata without reading the waveforms
       // if you are reading the waveforms, they are less efficient than getting what you want from raw
-      float radiantSampleRate(bool force_reload = false);
+      float sampleRate(bool force_reload = false);
       const float * radiantReadoutDelays(bool force_reload = false);  //size is mattak::k::num_radiant_channels, returning a float* since cppyyy doesn't seem to be able to deal with std::array properly
 
 

--- a/src/mattak/Header.h
+++ b/src/mattak/Header.h
@@ -14,7 +14,6 @@ typedef int rno_g_header_t;
 namespace mattak
 {
 
-
   class Header : public TObject
   {
 
@@ -36,9 +35,6 @@ namespace mattak
 
       /* The number of this station */
       uint16_t station_number = 0;
-
-      /* The number of samples in the waveforms */
-      uint16_t buffer_length = 0;
 
       /* In theory, the number of samples pretrigger, but not yet filled properly. */
       uint16_t pretrigger_samples = 0;
@@ -76,12 +72,9 @@ namespace mattak
       TriggerInfo trigger_info;
 
 
-    ClassDef(Header,2);
+    ClassDef(Header, 3);
   };
 
-
-
 }
-
 
 #endif

--- a/src/mattak/Header.h
+++ b/src/mattak/Header.h
@@ -43,22 +43,22 @@ namespace mattak
       double readout_time = 0;
 
       /* The number of PPS (pulse per second) received since the start of the run by the RADIANT. WARNING: this can slip */
-      uint32_t pps_num= 0;
+      uint32_t pps_num = 0;
 
       /* The number of cycles in the nominally 100 MHz clock for the current event. Note that this wraps every 53 seconds or so.
        * WARNING: this can slip.
        * */
-      uint32_t sysclk= 0;
+      uint32_t sysclk = 0;
 
       /** The number of cycles in the nominally 100 MHz clock at the time of the last PPS
        * WARNING: this can slip.
        * */
-      uint32_t sysclk_last_pps= 0;
+      uint32_t sysclk_last_pps = 0;
 
       /** The number of cycles in the nominally 100 MHz clock at the time of the  PPS previous to last
        * WARNING: this can slip.
        * */
-      uint32_t sysclk_last_last_pps= 0;
+      uint32_t sysclk_last_last_pps = 0;
 
       /* The trigger time, as a UTC double. Note that this does not have as much precision as is possible,
        * which should be fixed in the future (though you can rederive from sysclk).

--- a/src/mattak/Monitoring.h
+++ b/src/mattak/Monitoring.h
@@ -45,22 +45,35 @@ namespace mattak
       uint32_t run_number = 0;
       uint8_t station_number = 0;
 
-      // Trigger information
+      // Trigger information. A run is taken with a single digitizer, so only the RADIANT/LT
+      // counters or only the DIDAQ counters are non-zero (see mattak::Dataset::digitizer).
       uint32_t n_events = 0;
       uint32_t n_forced_triggers = 0;
       uint32_t n_lt_triggers = 0;
       uint32_t n_rf0_triggers = 0;
       uint32_t n_rf1_triggers = 0;
+      uint32_t n_didaq_coinc0_triggers = 0;
+      uint32_t n_didaq_coinc1_triggers = 0;
+      uint32_t n_didaq_surf_up_triggers = 0;
+      uint32_t n_didaq_surf_down_triggers = 0;
+      uint32_t n_didaq_deep_phased_triggers = 0;
 
-      // Per-channel average spectrum information
+      // Per-channel average spectrum information. A per-trigger-type spectrum is left empty if
+      // the run contains no event of that trigger type (in particular, all the DIDAQ ones are
+      // empty for a RADIANT run and vice versa).
       std::vector<float> frequencies; // frequencies of the FFT bins
       std::vector<std::vector<float>> avg_spectrum; // average spectrum per channel (e.g. average FFT amplitude per frequency bin)
       std::vector<std::vector<float>> avg_spectrum_force;
       std::vector<std::vector<float>> avg_spectrum_lt;
       std::vector<std::vector<float>> avg_spectrum_rf0;
       std::vector<std::vector<float>> avg_spectrum_rf1;
+      std::vector<std::vector<float>> avg_spectrum_didaq_coinc0;
+      std::vector<std::vector<float>> avg_spectrum_didaq_coinc1;
+      std::vector<std::vector<float>> avg_spectrum_didaq_surf_up;
+      std::vector<std::vector<float>> avg_spectrum_didaq_surf_down;
+      std::vector<std::vector<float>> avg_spectrum_didaq_deep_phased;
 
-    ClassDef(RunSummary, 1);
+    ClassDef(RunSummary, 2);
   };
 
 

--- a/src/mattak/TriggerInfo.h
+++ b/src/mattak/TriggerInfo.h
@@ -16,7 +16,7 @@ namespace mattak
     uint8_t RF_ncoinc[2] = {};
     uint8_t RF_window[2] = {};
 
-    ClassDef(RadiantTriggerInfo,2);
+    ClassDef(RadiantTriggerInfo, 2);
   };
 
   struct LTTriggerInfo
@@ -24,9 +24,22 @@ namespace mattak
     uint8_t window = 0;
     uint8_t num_coinc = 0;
     bool vppmode = 0;
-    uint8_t channel_mask=0;
-    uint16_t beam_mask=0;
-    ClassDef(LTTriggerInfo,2);
+    uint8_t channel_mask = 0;
+    uint16_t beam_mask = 0;
+    ClassDef(LTTriggerInfo, 2);
+  };
+
+  struct DidaqTriggerInfo
+  {
+    // DiDAQ replaces RADIANT/FLOWER; didaq_start_offsets is the union alternative to
+    // RadiantTriggerInfo::start_windows (see rno_g_header_t in rno-g.h).
+    uint16_t start_offsets[mattak::k::num_radiant_channels] = {};
+
+    uint16_t type = 0;
+    uint16_t channel_mask = 0;
+    uint16_t beam_mask = 0;
+
+    ClassDef(DidaqTriggerInfo, 1);
   };
 
   struct TriggerInfo
@@ -35,13 +48,19 @@ namespace mattak
     bool force_trigger = false;  // True if this is a force trigger (software triggER)
     bool pps_trigger = false;  // True if this is a trigger made by the PPS
     bool ext_trigger = false;  // True if this is an external trigger
+
     bool radiant_trigger = false;  // True if this is a trigger from the RADIANT tunnel diodes
     bool lt_trigger = false;  // True if this is a trigger from the low-threshold board
     int8_t which_radiant_trigger = -1; //which of the radiant triggers triggered. This is not reliably known so may be -1 even if radiant_trigger is true;
     int8_t which_lt_trigger = -1; //which lt trigger is used to make lt_trigger. 0 is the hi-lo and 1 is the phased. -1 for an error or not lt_trigger
+
+    bool didaq_trigger = false;  // True if this is an RF trigger from the DiDAQ digitizer
+
     RadiantTriggerInfo radiant_info;
     LTTriggerInfo lt_info;
-    ClassDef(TriggerInfo,3);
+    DidaqTriggerInfo didaq_info;
+
+    ClassDef(TriggerInfo, 4);
   };
 
 

--- a/src/mattak/TriggerInfo.h
+++ b/src/mattak/TriggerInfo.h
@@ -1,48 +1,48 @@
 #ifndef __MATTAK_TRIGGER_INFO_H__
 #define __MATTAK_TRIGGER_INFO_H__
 
-#include <stdint.h> 
-#include "TObject.h" 
-#include "mattak/Constants.h" 
+#include <stdint.h>
+#include "TObject.h"
+#include "mattak/Constants.h"
 
-namespace mattak 
+namespace mattak
 {
 
-  struct RadiantTriggerInfo 
+  struct RadiantTriggerInfo
   {
-    uint32_t channel_mask = 0; 
-    uint8_t start_windows[mattak::k::num_radiant_channels][2] = {}; 
-    uint32_t RF_masks[2] = {}; 
-    uint8_t RF_ncoinc[2] = {}; 
-    uint8_t RF_window[2] = {}; 
+    uint32_t channel_mask = 0;
+    uint8_t start_windows[mattak::k::num_radiant_channels][2] = {};
+    uint32_t RF_masks[2] = {};
+    uint8_t RF_ncoinc[2] = {};
+    uint8_t RF_window[2] = {};
 
-    ClassDef(RadiantTriggerInfo,2); 
-  }; 
+    ClassDef(RadiantTriggerInfo,2);
+  };
 
   struct LTTriggerInfo
   {
-    uint8_t window = 0; 
-    uint8_t num_coinc = 0; 
-    bool vppmode = 0; 
+    uint8_t window = 0;
+    uint8_t num_coinc = 0;
+    bool vppmode = 0;
     uint8_t channel_mask=0;
     uint16_t beam_mask=0;
-    ClassDef(LTTriggerInfo,2); 
-  }; 
+    ClassDef(LTTriggerInfo,2);
+  };
 
   struct TriggerInfo
   {
     bool rf_trigger = false;  // True if this is a type of RF trigger
     bool force_trigger = false;  // True if this is a force trigger (software triggER)
-    bool pps_trigger = false;  // True if this is a trigger made by the PPS 
+    bool pps_trigger = false;  // True if this is a trigger made by the PPS
     bool ext_trigger = false;  // True if this is an external trigger
     bool radiant_trigger = false;  // True if this is a trigger from the RADIANT tunnel diodes
     bool lt_trigger = false;  // True if this is a trigger from the low-threshold board
-    int8_t which_radiant_trigger = -1; //which of the radiant triggers triggered. This is not reliably known so may be -1 even if radiant_trigger is true; 
+    int8_t which_radiant_trigger = -1; //which of the radiant triggers triggered. This is not reliably known so may be -1 even if radiant_trigger is true;
     int8_t which_lt_trigger = -1; //which lt trigger is used to make lt_trigger. 0 is the hi-lo and 1 is the phased. -1 for an error or not lt_trigger
-    RadiantTriggerInfo radiant_info; 
-    LTTriggerInfo lt_info; 
-    ClassDef(TriggerInfo,3); 
-  }; 
+    RadiantTriggerInfo radiant_info;
+    LTTriggerInfo lt_info;
+    ClassDef(TriggerInfo,3);
+  };
 
 
 }

--- a/src/mattak/Waveforms.h
+++ b/src/mattak/Waveforms.h
@@ -103,7 +103,9 @@ namespace mattak
 
     // This has to stay 3200 MHz forever. This value will be used for all data taken with the
     // board manager version < 2.18(or 19), when we did not read out the sampling rate from the
-    // radiant directly.
+    // radiant directly. NOTE: we also use it to store the sampling rate of the DiDAQ (
+    // any readout digitizer really). We keep the name because changing it is painful and the
+    // variable is anyway not user facing since the Dataset interface sits between.
     uint32_t radiant_sampling_rate = 3200;  // MHz
     float digitizer_readout_delay_ns[mattak::k::num_radiant_channels] = {0};
 

--- a/src/mattak/Waveforms.h
+++ b/src/mattak/Waveforms.h
@@ -19,6 +19,11 @@ typedef int rno_g_waveform_t;
 #include "mattak/Header.h"
 #include "mattak/VoltageCalibration.h"
 
+#ifdef LIBRNO_G_SUPPORT
+static_assert(mattak::k::num_radiant_samples == RNO_G_MAX_RADIANT_NSAMPLES, "mattak::k::num_radiant_samples out of sync with librno-g");
+static_assert(mattak::k::num_didaq_samples == RNO_G_MAX_DIDAQ_NSAMPLES, "mattak::k::num_didaq_samples out of sync with librno-g");
+#endif
+
 namespace mattak
 {
   struct WaveformPlotOptions
@@ -102,9 +107,12 @@ namespace mattak
     uint32_t radiant_sampling_rate = 3200;  // MHz
     float digitizer_readout_delay_ns[mattak::k::num_radiant_channels] = {0};
 
+    // 2: samples are 12-bit RADIANT, in radiant_data. 1: samples are 8-bit DIDAQ, in didaq_data.
+    uint8_t bytes_per_sample = 2;
+
     virtual TGraph * makeGraph(int chan, bool ns = true) const = 0;
     virtual TVirtualPad* drawWaveforms(const WaveformPlotOptions & opt = WaveformPlotOptions(), TVirtualPad * where = nullptr) const = 0;
-    ClassDef(IWaveforms, 2);
+    ClassDef(IWaveforms, 3);
   };
 
   /**
@@ -119,12 +127,16 @@ namespace mattak
       Waveforms() { ; }
       Waveforms(const rno_g_waveform_t * wf);
 
-      //These are pedestal subtracted, so signed
+      //These are pedestal subtracted, so signed. Valid when bytes_per_sample == 2.
       int16_t radiant_data[mattak::k::num_radiant_channels][mattak::k::num_radiant_samples] = {};
+
+      //Raw, unsigned 8-bit DIDAQ samples. Valid when bytes_per_sample == 1.
+      uint8_t didaq_data[mattak::k::num_radiant_channels][mattak::k::num_didaq_samples] = {};
+
       virtual TGraph * makeGraph(int chan, bool ns = true) const;
       virtual TVirtualPad* drawWaveforms(const WaveformPlotOptions & opt = WaveformPlotOptions(), TVirtualPad * where = nullptr) const;
 
-    ClassDef(Waveforms, 3);
+    ClassDef(Waveforms, 4);
   };
 
 


### PR DESCRIPTION
Propagates changes to librno-g: https://github.com/RNO-G/librno-g/pull/15

Is that the opportunity to drop the uproot backend? Would be a clear cut... We could still support uproot for radiant/flower and supply bugfixes but we intentionally drop didaq support. 

List of changes:
- Implement new waveform field in Constructor (conditionally on runtime variable `bytes_per_sample`)
- Removed `buffer_length` (`radiant_nsamples`) from `Header.h`
- Embrace `RNO_G_INSTALL_DIR` concept in Makefile
- Downstream changes


ToDo's:

- [ ] Add new fields to RunInfo
- [x] Fully implementing pyroot backend

Low Prio:

- [ ] update rno-g-dump-* tools