### PR TITLE
Add scripts to automatically cleanup /data/rootified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ if (NOT DEFINED ROOTLESS)
       scripts/daq/rno-g-convert-run
       scripts/daq/rno-g-convert-station
       scripts/daq/rno-g-make-eventlists
+      scripts/daq/rno-g-cleanup-rootified
       scripts/voltage_calibration/convert_bias_scan_to_calibration.py
       scripts/monitoring/mon_write.py
     )

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is just a cmake wrapper
 
-.PHONY: all configure clean cleaner install cmake-build cmake-clean cmake-install cmake-rootless-build cmake-rootless-clean cmake-rootless-configure
+.PHONY: all configure clean cleaner install cmake-build cmake-clean cmake-install cmake-rootless-build cmake-rootless-clean cmake-rootless-configure install-systemd install-systemd-cleanup
 
 CMAKE?=cmake
 CCMAKE?=ccmake
@@ -9,6 +9,8 @@ rootlessdir=build-noroot
 SYSTEMD_DIR=/etc/systemd/system
 SERVICE_FILE=./scripts/services/rno-g-autoconverter@.service
 TARGET_FILE=./scripts/services/rno-g-autoconverter.target
+CLEANUP_SERVICE_FILE=./scripts/services/rno-g-cleanup-rootified.service
+CLEANUP_TIMER_FILE=./scripts/services/rno-g-cleanup-rootified.timer
 
 all: cmake-build #cmake-rootless-build
 rootless: cmake-rootless-build
@@ -64,3 +66,11 @@ install-systemd:
 	@cp $(TARGET_FILE) $(SYSTEMD_DIR)/rno-g-autoconverter.target
 	@systemctl daemon-reload
 	@echo "Done. (re)Start with: systemctl restart rno-g-autoconverter.target"
+
+# Install systemd service and timer for the daily rootified cleanup
+install-systemd-cleanup:
+	@echo "Installing rootified cleanup service and timer files..."
+	@cp $(CLEANUP_SERVICE_FILE) $(SYSTEMD_DIR)/rno-g-cleanup-rootified.service
+	@cp $(CLEANUP_TIMER_FILE) $(SYSTEMD_DIR)/rno-g-cleanup-rootified.timer
+	@systemctl daemon-reload
+	@echo "Done. Enable with: systemctl enable --now rno-g-cleanup-rootified.timer"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,11 @@ ROOT files). These are the production scripts used by the DAQ at the summit serv
   can be remade without reconverting everything.
 - `rno-g-check-daqstatus` — find runs missing `daqstatus.root` and convert just
   the daqstatus for them.
+- `rno-g-cleanup-rootified` — daily purge of old runs' bulk data (`*.root`,
+  `cfg/`, logs) under `rootified/` to reclaim disk space, run by the systemd
+  timer in [`services/`](services). Keeps the small files
+  `rno-g-convert-run` uses to detect an up-to-date run, so purged runs are
+  not reconverted. Runs marked with a `.keep` file are skipped.
 
 ## `metadata/`
 
@@ -75,5 +80,8 @@ systemd units and helpers for running the DAQ converter as a service.
 - `rno-g-autoconverter@.service`, `rno-g-autoconverter.target` — per-station
   service template and target. Installed with `make install-systemd` (see the
   top-level [`Makefile`](../Makefile)).
+- `rno-g-cleanup-rootified.service`, `rno-g-cleanup-rootified.timer` — daily
+  timer running `rno-g-cleanup-rootified`. Installed with
+  `make install-systemd-cleanup`.
 - `tmux_follow_services.sh` — open a tmux session tailing each station's journal.
 - `README.md` — service start/stop/log commands.

--- a/scripts/daq/rno-g-cleanup-rootified
+++ b/scripts/daq/rno-g-cleanup-rootified
@@ -89,6 +89,8 @@ for rundir in "${ROOTIFIED}"/station*/run*; do
   age_days=$(( age / 86400 ))
   if [ "$DRY_RUN" = "1" ]; then
     log_info "[dry-run] would purge ${rundir} (last modified ${age_days}d ago), keeping ${TOP_KEEP[*]} (aux/: ${AUX_KEEP[*]})"
+    find "$rundir" -mindepth 1 -maxdepth 1 "${top_prune_args[@]}"
+    find "${rundir}/aux" -mindepth 1 -maxdepth 1 "${aux_prune_args[@]}"
   else
     log_info "Purging ${rundir} (last modified ${age_days}d ago), keeping ${TOP_KEEP[*]} (aux/: ${AUX_KEEP[*]})"
     ok=1

--- a/scripts/daq/rno-g-cleanup-rootified
+++ b/scripts/daq/rno-g-cleanup-rootified
@@ -94,9 +94,9 @@ for rundir in "${ROOTIFIED}"/station*/run*; do
   else
     log_info "Purging ${rundir} (last modified ${age_days}d ago), keeping ${TOP_KEEP[*]} (aux/: ${AUX_KEEP[*]})"
     ok=1
-    find "$rundir" -mindepth 1 -maxdepth 1 "${top_prune_args[@]}" -exec rm -rf -- {} + || ok=0
+    find "$rundir" -mindepth 1 -maxdepth 1 "${top_prune_args[@]}" -exec rm -r -- {} + || ok=0
     if [ -d "${rundir}/aux" ]; then
-      find "${rundir}/aux" -mindepth 1 -maxdepth 1 "${aux_prune_args[@]}" -exec rm -rf -- {} + || ok=0
+      find "${rundir}/aux" -mindepth 1 -maxdepth 1 "${aux_prune_args[@]}" -exec rm -r -- {} + || ok=0
     fi
     if [ "$ok" -eq 1 ]; then
       n_purged=$((n_purged + 1))

--- a/scripts/daq/rno-g-cleanup-rootified
+++ b/scripts/daq/rno-g-cleanup-rootified
@@ -1,0 +1,107 @@
+#! /bin/bash
+
+# Purges the bulk data (*.root files, cfg/, logs, ...) of run directories
+# under ROOTIFIED whose most recently modified file is older than
+# MAX_AGE_DAYS. rootified-list.txt and aux/acq-file-list.txt are
+# deliberately kept: they are exactly what rno-g-convert-run checks to
+# decide whether a run is already up to date (see NEED_TO_UPDATE there), so
+# keeping them means the autoconverter will NOT reconvert a purged run from
+# scratch on its next pass. aux/comment.txt and aux/runinfo.txt are kept too
+# since they're tiny and hold useful run metadata; everything else in aux/
+# (e.g. flower_end.json.gz, which can be large) is purged like the rest.
+# Runs that were already purged are skipped without touching anything, so
+# their (necessarily old) remaining timestamps don't cause them to be
+# reprocessed every day.
+#
+# To exempt a run from being purged, create a marker file inside its run
+# directory:
+#   touch /data/rootified/station23/run1144/.keep
+#
+# Usage: rno-g-cleanup-rootified [max_age_days] [rootified_dir] [dry_run]
+
+shopt -s nullglob
+
+ROOT_DATA_DIR="${ROOT_DATA_DIR:-/data}"
+MAX_AGE_DAYS="${1:-30}"
+ROOTIFIED="${2:-${ROOT_DATA_DIR}/rootified}"
+DRY_RUN="${3:-0}"
+KEEP_MARKER=".keep"
+# Top-level entries a purged run keeps around. aux/ itself is kept (as a
+# directory) so its whitelisted contents (below) can survive inside it.
+TOP_KEEP=("$KEEP_MARKER" "rootified-list.txt" "aux" "monitoring.log")
+# Entries inside aux/ that survive the purge; everything else in aux/ is removed.
+AUX_KEEP=("acq-file-list.txt" "comment.txt" "runinfo.txt")
+
+log_info()  { echo "INFO:  $*"; }
+log_error() { echo "ERROR: $*" >&2; }
+
+if [ ! -d "$ROOTIFIED" ]; then
+  log_error "Rootified directory not found: $ROOTIFIED"
+  exit 1
+fi
+
+now=$(date +%s)
+cutoff=$(( MAX_AGE_DAYS * 86400 ))
+
+log_info "Purging runs older than ${MAX_AGE_DAYS}d under ${ROOTIFIED} (dry_run=${DRY_RUN})"
+
+n_purged=0
+n_already_purged=0
+n_kept_whitelist=0
+n_kept_age=0
+
+for rundir in "${ROOTIFIED}"/station*/run*; do
+  [ -d "$rundir" ] || continue
+
+  if [ -e "${rundir}/${KEEP_MARKER}" ]; then
+    n_kept_whitelist=$((n_kept_whitelist + 1))
+    continue
+  fi
+
+  top_prune_args=()
+  for name in "${TOP_KEEP[@]}"; do
+    top_prune_args+=(! -name "$name")
+  done
+  aux_prune_args=()
+  for name in "${AUX_KEEP[@]}"; do
+    aux_prune_args+=(! -name "$name")
+  done
+
+  top_candidates=$(find "$rundir" -mindepth 1 -maxdepth 1 "${top_prune_args[@]}")
+  aux_candidates=""
+  [ -d "${rundir}/aux" ] && aux_candidates=$(find "${rundir}/aux" -mindepth 1 -maxdepth 1 "${aux_prune_args[@]}")
+
+  if [ -z "$top_candidates" ] && [ -z "$aux_candidates" ]; then
+    n_already_purged=$((n_already_purged + 1))
+    continue
+  fi
+
+  newest=$(find "$rundir" -type f -printf '%T@\n' 2>/dev/null | sort -rn | head -n1)
+  newest=${newest%.*}
+  [ -z "$newest" ] && newest=$(stat -c '%Y' "$rundir")
+
+  age=$(( now - newest ))
+  if [ "$age" -le "$cutoff" ]; then
+    n_kept_age=$((n_kept_age + 1))
+    continue
+  fi
+
+  age_days=$(( age / 86400 ))
+  if [ "$DRY_RUN" = "1" ]; then
+    log_info "[dry-run] would purge ${rundir} (last modified ${age_days}d ago), keeping ${TOP_KEEP[*]} (aux/: ${AUX_KEEP[*]})"
+  else
+    log_info "Purging ${rundir} (last modified ${age_days}d ago), keeping ${TOP_KEEP[*]} (aux/: ${AUX_KEEP[*]})"
+    ok=1
+    find "$rundir" -mindepth 1 -maxdepth 1 "${top_prune_args[@]}" -exec rm -rf -- {} + || ok=0
+    if [ -d "${rundir}/aux" ]; then
+      find "${rundir}/aux" -mindepth 1 -maxdepth 1 "${aux_prune_args[@]}" -exec rm -rf -- {} + || ok=0
+    fi
+    if [ "$ok" -eq 1 ]; then
+      n_purged=$((n_purged + 1))
+    else
+      log_error "Failed to fully purge ${rundir}"
+    fi
+  fi
+done
+
+log_info "Done. purged=${n_purged} already_purged=${n_already_purged} kept_whitelisted=${n_kept_whitelist} kept_recent=${n_kept_age}"

--- a/scripts/services/README.md
+++ b/scripts/services/README.md
@@ -29,3 +29,32 @@ Restart a single station
 
 See logs for all stations together 
 `journalctl -u 'rno-g-autoconverter@*' -f`
+
+## Rootified cleanup
+
+Purges the bulk `*.root` files, `cfg/`, and logs of rootified runs
+(`/data/rootified/station*/run*`) older than 30 days (by last modification),
+once a day. `rootified-list.txt` and `aux/acq-file-list.txt` are
+deliberately kept: they are exactly what `rno-g-convert-run` checks to
+decide a run is already up to date, so keeping them stops the autoconverter
+from reconverting a purged run from scratch. `aux/comment.txt` and
+`aux/runinfo.txt` are kept too (tiny, useful metadata); everything else in
+`aux/` (e.g. `flower_end.json.gz`, which can be large) is purged along with
+the rest. To protect a run from being purged at all, create a `.keep` file
+inside its run directory, e.g.:
+`touch /data/rootified/station23/run1144/.keep`
+
+Install
+`sudo make install-systemd-cleanup`
+
+Enable and start the daily timer
+`sudo systemctl enable --now rno-g-cleanup-rootified.timer`
+
+Check when it last/next runs
+`systemctl status rno-g-cleanup-rootified.timer`
+
+See logs
+`journalctl -u rno-g-cleanup-rootified -f`
+
+Run it manually (dry-run, doesn't delete anything)
+`./scripts/daq/rno-g-cleanup-rootified 30 /data/rootified 1`

--- a/scripts/services/rno-g-cleanup-rootified.service
+++ b/scripts/services/rno-g-cleanup-rootified.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Clean up old rootified runs
+
+[Service]
+Type=oneshot
+User=rno-g
+WorkingDirectory=/home/rno-g/soft/mattak
+ExecStart=/home/rno-g/soft/mattak/scripts/daq/rno-g-cleanup-rootified 30

--- a/scripts/services/rno-g-cleanup-rootified.service
+++ b/scripts/services/rno-g-cleanup-rootified.service
@@ -5,4 +5,4 @@ Description=Clean up old rootified runs
 Type=oneshot
 User=rno-g
 WorkingDirectory=/home/rno-g/soft/mattak
-ExecStart=/home/rno-g/soft/mattak/scripts/install/bin/rno-g-cleanup-rootified 30
+ExecStart=/home/rno-g/soft/mattak/install/bin/rno-g-cleanup-rootified 30

--- a/scripts/services/rno-g-cleanup-rootified.service
+++ b/scripts/services/rno-g-cleanup-rootified.service
@@ -5,4 +5,4 @@ Description=Clean up old rootified runs
 Type=oneshot
 User=rno-g
 WorkingDirectory=/home/rno-g/soft/mattak
-ExecStart=/home/rno-g/soft/mattak/scripts/daq/rno-g-cleanup-rootified 30
+ExecStart=/home/rno-g/soft/mattak/scripts/install/bin/rno-g-cleanup-rootified 30

--- a/scripts/services/rno-g-cleanup-rootified.timer
+++ b/scripts/services/rno-g-cleanup-rootified.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily cleanup of old rootified runs
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
@cozzyd we talked about this a while ago. This implements a service to daily delete all rootified runs which are older than 30 (configurable) days. It keeps the meta data + the auxillary files such that the auto converter not reconverts the run. Furthermore can one label runs (by adding a `.keep` file to the run directory) if the should not be deleted.