### PR TITLE
Improving root conversion

### DIFF
--- a/prog/rno-g-convert.cc
+++ b/prog/rno-g-convert.cc
@@ -1,117 +1,137 @@
-#include <iostream> 
-#include "mattak/Waveforms.h" 
-#include "mattak/Header.h" 
-#include "mattak/Pedestals.h" 
-#include "mattak/DAQStatus.h" 
-#include "mattak/Converter.h" 
+#include <iostream>
+#include <cstring>
+#include "mattak/Waveforms.h"
+#include "mattak/Header.h"
+#include "mattak/Pedestals.h"
+#include "mattak/DAQStatus.h"
+#include "mattak/Converter.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-void usage() 
+void usage()
 {
-  std::cout << "Usage: rno-g-converter TYPE OUTFILE INFILE1 [INFILE2 ...]" << std::endl; 
-  std::cout << "   or rno-g-converter TYPE OUTFILE INDIR << std::endl" << std::endl; 
-  std::cout << "   or rno-g-converter runinfo OUTFILE  auxdir [stationoverride] [runoverride] << std::endl" << std::endl; 
-  std::cout << "   TYPE can be waveforms wfs header hd daqstatus ds pedestal ped runinfo" << std::endl; 
+  std::cout << "Usage: rno-g-converter [--update] TYPE OUTFILE INFILE1 [INFILE2 ...]" << std::endl;
+  std::cout << "   or rno-g-converter [--update] TYPE OUTFILE INDIR << std::endl" << std::endl;
+  std::cout << "   or rno-g-converter runinfo OUTFILE  auxdir [stationoverride] [runoverride] << std::endl" << std::endl;
+  std::cout << "   TYPE can be waveforms wfs header hd daqstatus ds pedestal ped runinfo" << std::endl;
   std::cout << "   OUTFILE is the output ROOT file " << std::endl;
-  std::cout << "   INFILE is one or more input files in order " << std::endl; 
-  std::cout << "   INDIR is an input directory, an attempt will be made to get any number from a string and sorted. " << std::endl; 
+  std::cout << "   INFILE is one or more input files in order " << std::endl;
+  std::cout << "   INDIR is an input directory, an attempt will be made to get any number from a string and sorted. " << std::endl;
+  std::cout << "   --update extends an existing OUTFILE with the inputs it does not hold yet," << std::endl;
+  std::cout << "            instead of converting everything again. Inputs already converted" << std::endl;
+  std::cout << "            are skipped; anything unexpected falls back to a full conversion." << std::endl;
 
-  exit(1); 
+  exit(1);
 
-} 
+}
 
-int isdir(const char * f) 
+int isdir(const char * f)
 {
-  struct stat st; 
-  if (stat(f,   &st) != 0) 
+  struct stat st;
+  if (stat(f,   &st) != 0)
   {
-    return 0; 
+    return 0;
   }
-  return S_ISDIR(st.st_mode); 
+  return S_ISDIR(st.st_mode);
 }
 
 
 
-int main (int nargs, char ** args) 
+int main (int nargs, char ** args)
 {
+  bool update = false;
+  int argi = 1;
 
-  if (nargs < 4) usage(); 
-  const char * type       = args[1]; 
-  const char * outfile    = args[2]; 
-  //check if outfile ends with .root 
-  if (!TString(outfile).EndsWith(".root"))
+  while (argi < nargs && args[argi][0] == '-')
   {
-    std::cerr << "Outfile should end with .root" << std::endl; 
-    return 1; 
+    if (!strcmp(args[argi], "--update") || !strcmp(args[argi], "-u"))
+    {
+      update = true;
+      argi++;
+    }
+    else
+    {
+      if (strcmp(args[argi], "--help") && strcmp(args[argi], "-h"))
+      {
+        std::cerr << "Unknown option: " << args[argi] << std::endl;
+      }
+      usage();
+    }
   }
 
-  
-  const char * firstinput = args[3]; 
-  int first_input_dir = isdir(firstinput); 
+  if (nargs - argi < 3) usage();
+
+  const char * type       = args[argi++];
+  const char * outfile    = args[argi++];
+  //check if outfile ends with .root
+  if (!TString(outfile).EndsWith(".root"))
+  {
+    std::cerr << "Outfile should end with .root" << std::endl;
+    return 1;
+  }
+
+
+  const char * firstinput = args[argi];
+  int first_input_dir = isdir(firstinput);
+  int nfiles = nargs - argi;
   int N = 0;
 
   if (!strcmp(type,"wf") || !strcmp(type,"waveforms"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertWaveformDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertWaveformDir(firstinput, outfile,0,0,update);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertWaveformFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertWaveformFiles(nfiles, (const char**) (args+argi), outfile, 0, -1, update);
     }
   }
   else if (!strcmp(type,"hd") || !strcmp(type,"header"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertHeaderDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertHeaderDir(firstinput, outfile,0,0,update);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertHeaderFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertHeaderFiles(nfiles, (const char**) (args+argi), outfile, 0, -1, update);
     }
   }
   else if (!strcmp(type,"ds") || !strcmp(type,"daqstatus"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertDAQStatusDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertDAQStatusDir(firstinput, outfile,0,0,update);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertDAQStatusFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertDAQStatusFiles(nfiles, (const char**) (args+argi), outfile, 0, -1, update);
     }
   }
   else if (!strcmp(type,"ped") || !strcmp(type,"pedestal"))
   {
-    if (first_input_dir) 
+    if (first_input_dir)
     {
-      N = mattak::convert::convertPedestalDir(firstinput, outfile,0,0); 
+      N = mattak::convert::convertPedestalDir(firstinput, outfile,0,0,update);
     }
-    else 
+    else
     {
-      N = mattak::convert::convertPedestalFiles(nargs-3, (const char**) (args+3), outfile); 
+      N = mattak::convert::convertPedestalFiles(nfiles, (const char**) (args+argi), outfile, 0, -1, update);
     }
   }
   else if (!strcmp(type,"runinfo"))
   {
-    return mattak::convert::makeRunInfo(firstinput,outfile, nargs > 4 ? atoi(args[4]) : -1, nargs > 5 ? atoi(args[5]) : -1 ); 
+    return mattak::convert::makeRunInfo(firstinput,outfile, nfiles > 1 ? atoi(args[argi+1]) : -1, nfiles > 2 ? atoi(args[argi+2]) : -1 );
   }
- 
+
   else
   {
-    std::cerr << "Unkown type: " << type << std::endl; 
-    return 1; 
+    std::cerr << "Unkown type: " << type << std::endl;
+    return 1;
   }
 
-  printf("Processed %d entries\n", N); 
-  return 0; 
+  printf("Processed %d entries\n", N);
+  return 0;
 }
-
-
-
-
-

--- a/scripts/daq/rno-g-convert-run
+++ b/scripts/daq/rno-g-convert-run
@@ -122,10 +122,19 @@ if [ ${NEED_TO_UPDATE} -eq 1 ] ; then
   # existing in the output directory
   calibration_file=("${OUTDIR}"/volCalConsts*)
 
+  # Waveforms and headers carry the run's event number, so rno-g-convert can
+  # extend the existing ROOT files with whatever arrived since the last pass
+  # rather than converting the whole run again. A forced run has to rebuild them
+  # from scratch, which is the whole point of forcing it.
+  # (daqstatus and pedestals have no event number and are small, so they keep
+  # being converted in full.)
+  UPDATE=--update
+  [ ${FORCE} -ne 0 ] && UPDATE=
+
   echo "Converting waveforms"  \
-    && rno-g-convert wf "${OUTDIR}/waveforms.root" "${INDIR}"/waveforms/* \
+    && rno-g-convert ${UPDATE} wf "${OUTDIR}/waveforms.root" "${INDIR}"/waveforms/* \
     && echo "Converting headers"  \
-    && rno-g-convert hd "${OUTDIR}/headers.root" "${INDIR}"/header/* \
+    && rno-g-convert ${UPDATE} hd "${OUTDIR}/headers.root" "${INDIR}"/header/* \
     && echo "Converting daqstatus" \
     && rno-g-convert ds "${OUTDIR}/daqstatus.root" "${INDIR}"/daqstatus/* \
     && echo "Converting pedestals" \

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -3,6 +3,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <algorithm>
+#include <string>
 #include <vector>
 #include "TTree.h"
 #include "TFile.h"
@@ -25,32 +26,136 @@ template<> const char * getName<mattak::DAQStatus>() { return "daqstatus"; }
 template<> const char * getName<mattak::Pedestals>() { return "pedestals"; }
 
 
+/* Incremental (update) conversion.
+ *
+ * A run is converted over and over while it is being taken, each time gaining
+ * only the handful of raw files which arrived since. Waveforms and headers carry
+ * the run's sequential event number, so an existing output file already says
+ * where to continue: everything up to the event number of its last entry is
+ * converted. Raw events at or below that are skipped and the rest appended.
+ *
+ * That needs no bookkeeping beside the data, and it recovers by itself from an
+ * interrupted conversion: ROOT commits a tree by rewriting its key, so a
+ * converter which is killed part way leaves the tree at its last committed
+ * length, and the next pass simply resumes from the event number it finds there.
+ * It also guarantees the result stays ordered, since an event is only ever
+ * appended if it comes after everything already in the tree.
+ */
+
+/** The event number of a raw record, or -1 for types which do not have one
+ * (pedestals, daqstatus) and are therefore always converted in full. */
+template <typename Traw> static long long rawEventNumber(const Traw &) { return -1; }
+template<> long long rawEventNumber(const rno_g_waveform_t & raw) { return raw.event_number; }
+template<> long long rawEventNumber(const rno_g_header_t & raw) { return raw.event_number; }
+
+template <typename Troot> static long long eventNumberOf(const Troot *) { return -1; }
+template<> long long eventNumberOf(const mattak::Waveforms * wf) { return wf->event_number; }
+template<> long long eventNumberOf(const mattak::Header * hd) { return hd->event_number; }
+
+
+/** The event number of the last entry already in outfile, or -1 if it cannot be
+ * appended to (no such file, no such tree, empty, or a type without event
+ * numbers) and has to be written from scratch.
+ */
+template <typename Troot>
+static long long lastConvertedEvent(const char * outfile, const char * treename)
+{
+  if (access(outfile, R_OK)) return -1;
+
+  // Read-only on purpose: opening a TFile for writing rewrites its header, and
+  // most passes turn out to have nothing to add at all.
+  TFile * f = TFile::Open(outfile, "READ");
+  if (!f || f->IsZombie())
+  {
+    ::Error("mattak::convert", "Could not open %s, converting from scratch", outfile);
+    delete f;
+    return -1;
+  }
+
+  long long last = -1;
+  TTree * t = (TTree *) f->Get(treename);
+
+  if (t && t->GetEntries() > 0)
+  {
+    Troot * b = 0;
+    t->SetBranchAddress(treename, &b);
+    if (t->GetEntry(t->GetEntries() - 1) > 0) last = eventNumberOf<Troot>(b);
+
+    // Event numbers are sequential within a run and start at 0, so a complete
+    // tree holds exactly last+1 entries. If any are missing -- a raw file which
+    // could not be read on an earlier pass, one which turned up only after later
+    // events had been converted, or one which was truncated -- then they all sit
+    // below `last`, where appending would never reach them again, and only
+    // converting from scratch brings them back.
+    //
+    // Counting from 0 assumes the whole run is converted at once, which is what
+    // rno-g-convert-run does (it hands over the entire waveforms/ glob).
+    // Converting only a later subset of a run would look like a gap here and be
+    // rebuilt on every pass: still correct, just not incremental.
+    if (last >= 0 && t->GetEntries() != last + 1)
+    {
+      ::Error("mattak::convert",
+              "%s holds %lld entries but its last event is %lld, so some are missing; converting from scratch",
+              outfile, (long long) t->GetEntries(), last);
+      last = -1;
+    }
+  }
+
+  delete f;
+  return last;
+}
+
+
 template <typename Traw, int(*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
 static int convert_impl(
     int N, const char ** infiles, const char * outfile,
-    const char * treename, int station)
+    const char * treename, int station, bool update)
 {
+  if (!treename) treename = getName<Troot>();
+
   TFile * f = 0;
   TTree * t = 0;
   Troot * b = 0;
 
+  const long long last = update ? lastConvertedEvent<Troot>(outfile, treename) : -1;
+  const bool appending = last >= 0;
+
   int nprocessed = 0;
   for (int i = 0; i < N; i++)
   {
-
     rno_g_file_handle h;
     if (0 == rno_g_init_handle(&h, infiles[i], "r"))
     {
       Traw raw;
       while (ReaderFn(h, &raw) > 0)
       {
+        if (appending && rawEventNumber<Traw>(raw) <= last) continue;
+
+        // Opened only once there is something to write, so that a pass which
+        // finds nothing new leaves the file untouched.
         if (!f)
         {
-          f = new TFile(outfile, "RECREATE");
-          if (!treename) treename = getName<Troot>();
-          t = new TTree(treename, treename);
-          b = new Troot;
-          t->Branch(treename, &b);
+          if (appending)
+          {
+            f = TFile::Open(outfile, "UPDATE");
+            t = f && !f->IsZombie() ? (TTree *) f->Get(treename) : 0;
+            if (!t)
+            {
+              ::Error("mattak::convert", "Could not reopen %s to append to", outfile);
+              delete f;
+              rno_g_close_handle(&h);
+              return 0;
+            }
+            b = new Troot;
+            t->SetBranchAddress(treename, &b);
+          }
+          else
+          {
+            f = new TFile(outfile, "RECREATE");
+            t = new TTree(treename, treename);
+            b = new Troot;
+            t->Branch(treename, &b);
+          }
         }
 
         nprocessed++;
@@ -60,12 +165,16 @@ static int convert_impl(
       }
       rno_g_close_handle(&h);
     }
-
+    else
+    {
+      ::Error("mattak::convert", "Could not open %s", infiles[i]);
+    }
   }
 
   if (f)
   {
-    f->Write();
+    if (appending) t->Write("", TObject::kOverwrite);
+    else f->Write();
     delete f;
     f = 0;
   }
@@ -75,7 +184,7 @@ static int convert_impl(
 
 
 template <typename Traw, int (*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
-static int convert_dir(const char * dir, const char * outfile, const char * treename, int station)
+static int convert_dir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
   std::vector<std::string> files;
   std::vector<const char *> file_ptrs;
@@ -100,73 +209,74 @@ static int convert_dir(const char * dir, const char * outfile, const char * tree
   std::sort(files.begin(), files.end());
 
   file_ptrs.reserve(files.size());
-  for (auto f : files)
+  // by reference: a copy would leave file_ptrs full of dangling pointers
+  for (const auto & f : files)
   {
     file_ptrs.push_back(f.c_str());
   }
 
-  return convert_impl<Traw,ReaderFn,Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename,station);
+  return convert_impl<Traw, ReaderFn, Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename, station, update);
 }
 
 
-int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
+int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename,station);
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename, station, update);
 }
 
-int mattak::convert::convertWaveformFile(const char * infile, const char * outfile, const char * treename,int station)
+int mattak::convert::convertWaveformFile(const char * infile, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename,station);
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename, station, update);
 }
 
-int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename,int station)
+int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename,station);
+  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename, station, update);
 }
 
-int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
+int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename,station);
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename, station, update);
 }
 
-int mattak::convert::convertHeaderFile(const char * infile, const char * outfile, const char * treename,int station)
+int mattak::convert::convertHeaderFile(const char * infile, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename,station);
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename, station, update);
 }
 
-int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename,int station)
+int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename,station);
+  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename, station, update);
 }
 
-int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
+int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename,station);
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename, station, update);
 }
 
-int mattak::convert::convertDAQStatusFile(const char * infile, const char * outfile, const char * treename,int station)
+int mattak::convert::convertDAQStatusFile(const char * infile, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename,station);
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename, station, update);
 }
 
-int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename,int station)
+int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename,station);
+  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename, station, update);
 }
 
-int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
+int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename,station);
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename, station, update);
 }
 
-int mattak::convert::convertPedestalFile(const char * infile, const char * outfile, const char * treename,int station)
+int mattak::convert::convertPedestalFile(const char * infile, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename,station);
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename, station, update);
 }
 
-int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename,int station)
+int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename, int station, bool update)
 {
-  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename,station);
+  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename, station, update);
 }
 
 

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -78,25 +78,23 @@ static long long lastConvertedEvent(const char * outfile, const char * treename)
   if (t && t->GetEntries() > 0)
   {
     Troot * b = 0;
+    long long first = -1;
     t->SetBranchAddress(treename, &b);
+
+    if (t->GetEntry(0) > 0) first = eventNumberOf<Troot>(b);
     if (t->GetEntry(t->GetEntries() - 1) > 0) last = eventNumberOf<Troot>(b);
 
-    // Event numbers are sequential within a run and start at 0, so a complete
-    // tree holds exactly last+1 entries. If any are missing -- a raw file which
+    // Event numbers are sequential, so a complete tree holds every one of them
+    // between its first and its last. If any are missing -- a raw file which
     // could not be read on an earlier pass, one which turned up only after later
     // events had been converted, or one which was truncated -- then they all sit
     // below `last`, where appending would never reach them again, and only
     // converting from scratch brings them back.
-    //
-    // Counting from 0 assumes the whole run is converted at once, which is what
-    // rno-g-convert-run does (it hands over the entire waveforms/ glob).
-    // Converting only a later subset of a run would look like a gap here and be
-    // rebuilt on every pass: still correct, just not incremental.
-    if (last >= 0 && t->GetEntries() != last + 1)
+    if ((first >= 0 && last >= 0 && t->GetEntries() != last - first + 1) || first > 10)
     {
       ::Error("mattak::convert",
-              "%s holds %lld entries but its last event is %lld, so some are missing; converting from scratch",
-              outfile, (long long) t->GetEntries(), last);
+              "%s holds %lld entries but spans events %lld..%lld, so some are missing; converting from scratch",
+              outfile, (long long) t->GetEntries(), first, last);
       last = -1;
     }
   }

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -1,8 +1,8 @@
-#include <sys/types.h> 
-#include <dirent.h> 
-#include <sys/stat.h> 
-#include <unistd.h> 
-#include <algorithm> 
+#include <sys/types.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <algorithm>
 #include <vector>
 #include "TTree.h"
 #include "TFile.h"
@@ -16,182 +16,178 @@
 
 
 #ifdef LIBRNO_G_SUPPORT
-#include "rno-g.h" 
+#include "rno-g.h"
 
-template <typename T> const char * getName() { return "unnamed"; } 
-template<> const char * getName<mattak::Waveforms>() { return "waveforms"; } 
-template<> const char * getName<mattak::Header>() { return "header"; } 
-template<> const char * getName<mattak::DAQStatus>() { return "daqstatus"; } 
-template<> const char * getName<mattak::Pedestals>() { return "pedestals"; } 
-
+template <typename T> const char * getName() { return "unnamed"; }
+template<> const char * getName<mattak::Waveforms>() { return "waveforms"; }
+template<> const char * getName<mattak::Header>() { return "header"; }
+template<> const char * getName<mattak::DAQStatus>() { return "daqstatus"; }
+template<> const char * getName<mattak::Pedestals>() { return "pedestals"; }
 
 
 template <typename Traw, int(*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
-static int convert_impl(int N, const char ** infiles, const char * outfile, const char * treename, int station)
-
+static int convert_impl(
+    int N, const char ** infiles, const char * outfile,
+    const char * treename, int station)
 {
-  TFile * f = 0; 
-  TTree *t = 0; 
-  Troot * b = 0; 
+  TFile * f = 0;
+  TTree * t = 0;
+  Troot * b = 0;
 
-  int nprocessed = 0; 
-  for (int i = 0; i < N; i++) 
+  int nprocessed = 0;
+  for (int i = 0; i < N; i++)
   {
 
-    rno_g_file_handle h; 
-    if (0 == rno_g_init_handle(&h, infiles[i], "r")) 
+    rno_g_file_handle h;
+    if (0 == rno_g_init_handle(&h, infiles[i], "r"))
     {
-      Traw raw; 
-      while (ReaderFn(h, &raw) > 0) 
+      Traw raw;
+      while (ReaderFn(h, &raw) > 0)
       {
-        if (!f) 
+        if (!f)
         {
-          f = new TFile(outfile,"RECREATE"); 
-          if (!treename) treename = getName<Troot>(); 
-          t = new TTree(treename,treename); 
-          b = new Troot; 
-          t->Branch(treename, &b); 
+          f = new TFile(outfile, "RECREATE");
+          if (!treename) treename = getName<Troot>();
+          t = new TTree(treename, treename);
+          b = new Troot;
+          t->Branch(treename, &b);
         }
 
-        nprocessed++; 
-        b = new (b) Troot(&raw); 
-        if (station > 0) b->station_number = station; 
-        t->Fill(); 
+        nprocessed++;
+        b = new (b) Troot(&raw);
+        if (station > 0) b->station_number = station;
+        t->Fill();
       }
-      rno_g_close_handle(&h); 
+      rno_g_close_handle(&h);
     }
 
   }
 
   if (f)
   {
-    f->Write(); 
+    f->Write();
     delete f;
-    f = 0; 
+    f = 0;
   }
 
-  return nprocessed; 
+  return nprocessed;
 }
-
-
 
 
 template <typename Traw, int (*ReaderFn)(rno_g_file_handle_t, Traw*), typename Troot>
 static int convert_dir(const char * dir, const char * outfile, const char * treename, int station)
 {
-  std::vector<std::string> files; 
-  std::vector<const char *> file_ptrs; 
-  DIR * dirp = opendir(dir); 
+  std::vector<std::string> files;
+  std::vector<const char *> file_ptrs;
+  DIR * dirp = opendir(dir);
   if (!dirp)
   {
     ::Error("mattak::convert::convert_dir", "Could not open dir %s", dir);
     return 0;
   }
 
-  struct dirent * dent; 
-
+  struct dirent * dent;
 
   while ((dent = readdir(dirp)))
   {
-    std::string fname = dir; 
-    fname+="/"; 
-    fname+=dent->d_name; 
-    files.push_back(fname); 
+    std::string fname = dir;
+    fname += "/";
+    fname += dent->d_name;
+    files.push_back(fname);
   }
 
-  closedir(dirp); 
-  std::sort(files.begin(), files.end()); 
+  closedir(dirp);
+  std::sort(files.begin(), files.end());
 
-  file_ptrs.reserve(files.size()); 
-  for (auto f : files) 
+  file_ptrs.reserve(files.size());
+  for (auto f : files)
   {
-    file_ptrs.push_back(f.c_str()); 
+    file_ptrs.push_back(f.c_str());
   }
 
-  return convert_impl<Traw,ReaderFn,Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename,station); 
+  return convert_impl<Traw,ReaderFn,Troot>(file_ptrs.size(), &file_ptrs[0], outfile, treename,station);
 }
 
 
-int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertWaveformFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertWaveformDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_waveform_t, rno_g_waveform_read, mattak::Waveforms>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertHeaderFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_header_t, rno_g_header_read, mattak::Header>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertHeaderDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_header_t, rno_g_header_read, mattak::Header>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertDAQStatusFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertDAQStatusDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_daqstatus_t, rno_g_daqstatus_read, mattak::DAQStatus>(dir, outfile, treename,station);
 }
 
-int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename,station); 
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(nfiles, infiles, outfile, treename,station);
 }
 
 int mattak::convert::convertPedestalFile(const char * infile, const char * outfile, const char * treename,int station)
 {
-  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename,station); 
+  return convert_impl<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(1, &infile, outfile, treename,station);
 }
 
-int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename,int station) 
+int mattak::convert::convertPedestalDir(const char * dir, const char * outfile, const char * treename,int station)
 {
-  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename,station); 
+  return convert_dir<rno_g_pedestal_t, rno_g_pedestal_read, mattak::Pedestals>(dir, outfile, treename,station);
 }
 
 
 #endif
 
-int mattak::convert::makeRunInfo(const char *auxdir, const char * outfile, int station_override, int run_override) 
+int mattak::convert::makeRunInfo(const char *auxdir, const char * outfile, int station_override, int run_override)
 {
-  TFile of(outfile,"RECREATE"); 
-  RunInfo * ri = new RunInfo(auxdir); 
-  if (station_override > 0) 
+  TFile of(outfile,"RECREATE");
+  RunInfo * ri = new RunInfo(auxdir);
+  if (station_override > 0)
   {
-    ri->station = station_override; 
+    ri->station = station_override;
   }
 
-  if (run_override > 0) 
+  if (run_override > 0)
   {
-    ri->run = run_override; 
+    ri->run = run_override;
   }
 
-//  ri->Dump(); 
-  ri->Write("info"); 
+  //ri->Dump();
+  ri->Write("info");
   of.Close();
-  return 0; 
+  return 0;
 }
-

--- a/src/mattak/Converter.h
+++ b/src/mattak/Converter.h
@@ -7,24 +7,37 @@ namespace mattak
   {
 #ifdef LIBRNO_G_SUPPORT
 
-    int convertWaveformFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertWaveformDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    /* All of these take an `update` flag. With it set, an output file which
+     * already exists is extended with whatever input files are not in it yet,
+     * instead of being written from scratch. That is what makes converting a
+     * run which is still being taken cheap, since each pass then only pays for
+     * the raw files which arrived since the last one.
+     *
+     * Which input files an output file holds is recorded inside it, so this is
+     * safe to repeat: files already converted are skipped, and anything the
+     * record does not explain (an input file which changed, one which appeared
+     * before a file already converted, a mismatched entry count, an output file
+     * which cannot be opened) falls back to converting from scratch.
+     */
 
-    int convertHeaderFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertHeaderDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertWaveformFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertWaveformFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertWaveformDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
 
-    int convertDAQStatusFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertDAQStatusDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertHeaderFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertHeaderFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertHeaderDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
 
-    int convertPedestalFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1); 
-    int convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1); 
-    int convertPedestalDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1); 
+    int convertDAQStatusFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertDAQStatusFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertDAQStatusDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+
+    int convertPedestalFile(const char * infile, const char *outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertPedestalFiles(int nfiles, const char ** infiles, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
+    int convertPedestalDir(const char * dir, const char * outfile, const char * treename =0, int station_override=-1, bool update=false);
 
 #endif
-    int makeRunInfo(const char * auxdir, const char * outfile, int station_override = -1, int run_override =-1); 
+    int makeRunInfo(const char * auxdir, const char * outfile, int station_override = -1, int run_override =-1);
   }
 }
 


### PR DESCRIPTION
This adds a new feature to the root conversion. It allows headers.root and waveforms.root files to be appended with new data instead of being rewritten entirely. The converter checks strictly that the sequence of events is in order and complete. If not it falls back to re-converting everything. 

Please enable hide whitespace! 